### PR TITLE
Fix Windows SDRplay runtime packaging

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,15 +83,25 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Package Linux and macOS releases
-        run: >-
-          ./gradlew --no-configuration-cache runtimeZipOthers
-          -PprojectVersion=nightly -PupdateTrack=nightly -PupdateBuild=${UPDATE_BUILD}
-
       - name: Package Windows releases
         run: >-
-          ./gradlew --no-configuration-cache runtimeZipWindows
+          ./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win
           -PprojectVersion=nightly -PupdateTrack=nightly -PupdateBuild=${UPDATE_BUILD}
+
+      - name: Preserve Windows release packages
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/sdrtrunk-vce-windows-packages"
+          cp build/image/sdrtrunk-vce-windows-*.zip "${RUNNER_TEMP}/sdrtrunk-vce-windows-packages/"
+
+      - name: Package Linux and macOS releases
+        run: >-
+          ./gradlew --no-configuration-cache clean runtimeZipOthers
+          -PprojectVersion=nightly -PupdateTrack=nightly -PupdateBuild=${UPDATE_BUILD}
+
+      - name: Restore Windows release packages
+        shell: bash
+        run: cp "${RUNNER_TEMP}/sdrtrunk-vce-windows-packages/"*.zip build/image/
 
       - name: Refuse an out-of-order nightly publication
         shell: bash

--- a/README.md
+++ b/README.md
@@ -258,9 +258,12 @@ Package tasks:
 
 ```bash
 ./gradlew runtimeZipCurrent -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
-./gradlew --no-configuration-cache runtimeZipWindows -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
-./gradlew --no-configuration-cache runtimeZipOthers -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
+./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
+./gradlew --no-configuration-cache clean runtimeZipOthers -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
 ```
+
+Each cross-platform package command starts from a clean build. If you are collecting every platform package, copy
+the first command's ZIP files outside `build/image` before running the second command, then restore them afterward.
 
 Build output is written under `build/image`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 
 
@@ -46,7 +47,7 @@ import java.util.zip.ZipFile
  * Note: release images are located in the /build/image/ directory
  *
  * Scenario 4: create release for Windows operating system using downloaded JDK
- * command: ./gradlew runtimeZipWindows
+ * command: ./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win
  * Note: release image is located in the /build/image/ directory
  */
 plugins {
@@ -66,6 +67,17 @@ def bouncyCastleVersion = "1.84"
 def currentJavafxPlatform = org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.currentOperatingSystem.isWindows() ? "win" :
     (org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.currentOperatingSystem.isMacOsX() ? "mac" : "linux")
 def javafxPlatform = project.findProperty('javafxPlatform') ?: currentJavafxPlatform
+def requestedTaskNames = gradle.startParameter.taskNames.collect { taskName ->
+    taskName.tokenize(':').last()
+}
+def configurationCacheRequested = gradle.startParameter.configurationCacheRequested
+
+if(requestedTaskNames.contains('runtimeZipWindows') &&
+        (javafxPlatform != 'win' || configurationCacheRequested ||
+                requestedTaskNames != ['clean', 'runtimeZipWindows'])) {
+    throw new GradleException('runtimeZipWindows must run by itself as a clean Windows-target invocation: ' +
+            './gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win ...')
+}
 
 //JIDE 3.6.18 references the Windows look-and-feel class directly.  Non-Windows JDKs need the
 //compatibility stub, while Windows must use the real java.desktop class to avoid a split package.
@@ -407,6 +419,13 @@ test {
 }
 
 jar {
+    inputs.property('javafxPlatform', javafxPlatform)
+
+    if(javafxPlatform == 'win') {
+        //A stale non-Windows compilation must never place this compatibility class in a Windows application JAR.
+        exclude 'com/sun/java/swing/plaf/windows/WindowsLookAndFeel.class'
+    }
+
     manifest {
         attributes (
                 'Implementation-Title'  : 'sdrtrunk-vce project',
@@ -934,6 +953,53 @@ def windowsArchiveDescriptors = { org.beryx.runtime.RuntimeZipTask runtimeZipTas
     descriptors
 }
 
+def verifyWindowsApplicationArchive = { ZipFile zip, Map<String, Object> descriptor ->
+    String archiveRuntimeRoot = descriptor.archiveRuntimeRoot as String
+    String archiveApplicationRoot = archiveRuntimeRoot.substring(0,
+            archiveRuntimeRoot.length() - 'bin/'.length())
+    String launcherEntryName = "${archiveApplicationRoot}bin/${project.name}.bat"
+    def launcherEntry = zip.getEntry(launcherEntryName)
+
+    if(launcherEntry == null || launcherEntry.directory) {
+        throw new GradleException("Windows launcher is missing from ZIP: ${launcherEntryName}")
+    }
+
+    String launcherText
+    zip.getInputStream(launcherEntry).withCloseable { input ->
+        launcherText = input.getText('UTF-8')
+    }
+
+    [
+        '--add-exports=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED',
+        '-Djava.library.path=c:\\Program Files\\SDRplay\\API\\x64'
+    ].each { requiredArgument ->
+        if(!launcherText.contains(requiredArgument)) {
+            throw new GradleException("Windows launcher ${launcherEntryName} is missing ${requiredArgument}")
+        }
+    }
+
+    String applicationJarEntryName = "${archiveApplicationRoot}lib/${project.name}-${version}.jar"
+    def applicationJarEntry = zip.getEntry(applicationJarEntryName)
+
+    if(applicationJarEntry == null || applicationJarEntry.directory) {
+        throw new GradleException("Windows application JAR is missing from ZIP: ${applicationJarEntryName}")
+    }
+
+    String compatibilityEntryName = 'com/sun/java/swing/plaf/windows/WindowsLookAndFeel.class'
+    zip.getInputStream(applicationJarEntry).withCloseable { input ->
+        new ZipInputStream(input).withCloseable { applicationJar ->
+            def nestedEntry
+
+            while((nestedEntry = applicationJar.nextEntry) != null) {
+                if(nestedEntry.name == compatibilityEntryName) {
+                    throw new GradleException("Windows application JAR contains non-Windows compatibility class: " +
+                            compatibilityEntryName)
+                }
+            }
+        }
+    }
+}
+
 /* Verify the bytes that were actually written to each Windows archive, not only the intermediate runtime image. */
 tasks.withType(org.beryx.runtime.RuntimeZipTask).configureEach { runtimeZipTask ->
     inputs.files(providers.provider {
@@ -955,6 +1021,8 @@ tasks.withType(org.beryx.runtime.RuntimeZipTask).configureEach { runtimeZipTask 
             ZipFile zip = new ZipFile(archive)
 
             try {
+                verifyWindowsApplicationArchive(zip, descriptor)
+
                 zip.entries().toList().findAll { entry ->
                     !entry.directory && entry.name.startsWith(archiveRuntimeRoot) &&
                         (entry.name.toLowerCase(Locale.ROOT).endsWith('.exe') ||
@@ -1040,11 +1108,14 @@ tasks.register('runtimeZipCurrent', org.beryx.runtime.RuntimeZipTask) {rt ->
  *
  * Note: you cannot create both Windows and Linux releases at the same time due to limitations of the Runtime plugin
  *
- * Usage: gradle runtimeZipWindows
- * Usage: gradlew runtimeZipWindows   (windows - using gradlew)
- * Usage: ./gradlew runtimeZipWindows   (linux - using gradlew)
+ * Usage: gradle --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win
+ * Usage: gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win   (windows)
+ * Usage: ./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win   (linux/macOS)
  */
 tasks.register('runtimeZipWindows', org.beryx.runtime.RuntimeZipTask) {rt ->
+    outputs.upToDateWhen { false }
+    mustRunAfter(tasks.named('clean'))
+
     //Windows aarch64
     if(file(jdk_windows_aarch64).exists()) {
         rt.extension.targetPlatform(targetWindowsAarch64, jdk_windows_aarch64, [])
@@ -1065,6 +1136,28 @@ tasks.register('runtimeZipWindows', org.beryx.runtime.RuntimeZipTask) {rt ->
     }
 
     configure(rt, jvmArgsWindows, true)
+
+    doFirst {
+        def cleanTask = tasks.named('clean').get()
+
+        if(javafxPlatform != 'win' || configurationCacheRequested ||
+                requestedTaskNames != ['clean', 'runtimeZipWindows'] ||
+                !cleanTask.state.executed || cleanTask.state.failure != null) {
+            throw new GradleException('runtimeZipWindows must run by itself as a clean Windows-target invocation: ' +
+                    './gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win ...')
+        }
+
+        Set<String> expectedTargets = [targetWindowsAarch64, targetWindowsX86_64] as Set
+        Set<String> actualTargets = rt.extension.targetPlatforms.get().keySet() as Set
+
+        if(actualTargets != expectedTargets) {
+            throw new GradleException("runtimeZipWindows has unexpected target platforms: ${actualTargets}")
+        }
+
+        if(rt.extension.launcherData.get().jvmArgsOrDefault != jvmArgsWindows) {
+            throw new GradleException('runtimeZipWindows does not contain the required Windows launcher arguments')
+        }
+    }
 }
 
 /**

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryHelper.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryHelper.java
@@ -46,47 +46,50 @@ public class SDRPlayLibraryHelper
     private static final String SDRPLAY_API_PATH_LINUX = "/usr/local/lib/libsdrplay_api.so";
     private static final String SDRPLAY_API_PATH_MAC_OS = "/usr/local/lib/libsdrplay_api.dylib";
     private static final String SDRPLAY_API_PATH_MAC_OS_ALTERNATE = "/usr/local/lib/libsdrplay_api.so";
-    private static final String SDRPLAY_API_PATH_WINDOWS = System.getenv("ProgramFiles") +
-            "\\SDRplay\\API\\x64\\" + SDRPLAY_API_LIBRARY_NAME;
 
     public static final boolean LOADED;
     public static final boolean LOADED_FROM_PATH;
-    public static final Path LIBRARY_PATH = Path.of(getSDRplayLibraryPath());
+    public static final Path LIBRARY_PATH;
 
     static
     {
         boolean loaded = false;
         boolean loadedFromPath = false;
+        Path libraryPath = resolveSDRplayLibraryPath();
+        LIBRARY_PATH = libraryPath != null ? libraryPath : Path.of("");
 
         try
         {
             System.loadLibrary(SDRPLAY_API_LIBRARY_NAME);
-            mLog.info("SDRPLay API library loaded by name [" + SDRPLAY_API_LIBRARY_NAME + "]");
+            mLog.info("SDRPlay API library loaded by name [" + SDRPLAY_API_LIBRARY_NAME + "]");
             loaded = true;
         }
         catch(Throwable t)
         {
-            String libraryPath = getSDRplayLibraryPath();
-            Path path = Path.of(libraryPath);
-            boolean exists = Files.exists(path);
-
-            if(exists)
+            if(libraryPath != null && Files.isRegularFile(libraryPath))
             {
                 try
                 {
-                    System.load(libraryPath);
-                    mLog.info("SDRPLay API library loaded by path [" + libraryPath + "]");
+                    System.load(libraryPath.toString());
+                    mLog.info("SDRPlay API library loaded by path [" + libraryPath + "]");
                     loaded = true;
                     loadedFromPath = true;
                 }
                 catch(Throwable t2)
                 {
-                    mLog.info("SDRPlay API native library not found at " + libraryPath);
+                    mLog.warn("SDRPlay API native library was found but could not be loaded from [" + libraryPath + "]");
+                    mLog.debug("SDRPlay API native library load failure", t2);
                 }
+            }
+            else if(libraryPath != null)
+            {
+                mLog.info("SDRPlay API native library not found at: " + libraryPath);
+                mLog.debug("SDRPlay API native library was not available by name", t);
             }
             else
             {
-                mLog.info("SDRPlay API native library not found at: " + libraryPath);
+                mLog.info("SDRPlay API native library path is unavailable for this operating system");
+                mLog.debug("SDRPlay API native library was not available by name", t);
             }
         }
 
@@ -99,28 +102,37 @@ public class SDRPlayLibraryHelper
      */
     public static String getSDRplayLibraryPath()
     {
+        return LIBRARY_PATH.toString();
+    }
+
+    /**
+     * Resolves the platform-specific SDRplay native library path.
+     */
+    private static Path resolveSDRplayLibraryPath()
+    {
         if(SystemUtils.IS_OS_WINDOWS)
         {
-            return SDRPLAY_API_PATH_WINDOWS;
+            return SDRPlayLibraryPathResolver.resolveWindows(System.getenv("ProgramFiles"), System::mapLibraryName)
+                    .orElse(null);
         }
         else if(SystemUtils.IS_OS_LINUX)
         {
-            return SDRPLAY_API_PATH_LINUX;
+            return Path.of(SDRPLAY_API_PATH_LINUX);
         }
         else if(SystemUtils.IS_OS_MAC_OSX)
         {
             //API versions 3.14 and earlier used a (.so) extension and 3.15 and later use the (.dylib) extension
             if(Files.exists(Path.of(SDRPLAY_API_PATH_MAC_OS)))
             {
-                return SDRPLAY_API_PATH_MAC_OS;
+                return Path.of(SDRPLAY_API_PATH_MAC_OS);
             }
             else
             {
-                return SDRPLAY_API_PATH_MAC_OS_ALTERNATE;
+                return Path.of(SDRPLAY_API_PATH_MAC_OS_ALTERNATE);
             }
         }
 
         mLog.error("Unrecognized operating system.  Cannot identify sdrplay api library path");
-        return "";
+        return null;
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolver.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolver.java
@@ -1,0 +1,48 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Dennis Sheirer
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.source.tuner.sdrplay.api;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+/**
+ * Resolves platform-specific SDRplay API native library paths without loading the library.
+ */
+final class SDRPlayLibraryPathResolver
+{
+    private static final String SDRPLAY_API_LIBRARY_NAME = "sdrplay_api";
+
+    private SDRPlayLibraryPathResolver()
+    {
+    }
+
+    /**
+     * Resolves the installed 64-bit Windows SDRplay API library.
+     *
+     * @param programFiles Windows Program Files directory
+     * @param libraryNameMapper maps a base native library name to its platform filename
+     * @return resolved absolute library path, or empty when the installation root is unavailable
+     */
+    static Optional<Path> resolveWindows(String programFiles, UnaryOperator<String> libraryNameMapper)
+    {
+        if(programFiles == null || programFiles.isBlank())
+        {
+            return Optional.empty();
+        }
+
+        String libraryFileName = libraryNameMapper.apply(SDRPLAY_API_LIBRARY_NAME);
+
+        if(libraryFileName == null || libraryFileName.isBlank())
+        {
+            return Optional.empty();
+        }
+
+        return Optional.of(Path.of(programFiles, "SDRplay", "API", "x64", libraryFileName)
+                .toAbsolutePath().normalize());
+    }
+}

--- a/src/test/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolverTest.java
+++ b/src/test/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolverTest.java
@@ -1,0 +1,48 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Dennis Sheirer
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.source.tuner.sdrplay.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SDRPlayLibraryPathResolverTest
+{
+    @TempDir
+    Path mProgramFiles;
+
+    @Test
+    void resolvesMappedWindowsDllFilename()
+    {
+        Path expected = mProgramFiles.resolve("SDRplay/API/x64/sdrplay_api.dll").toAbsolutePath().normalize();
+        Path resolved = SDRPlayLibraryPathResolver.resolveWindows(mProgramFiles.toString(), libraryName ->
+        {
+            assertEquals("sdrplay_api", libraryName);
+            return "sdrplay_api.dll";
+        }).orElseThrow();
+
+        assertEquals(expected, resolved);
+        assertEquals("sdrplay_api.dll", resolved.getFileName().toString());
+    }
+
+    @Test
+    void rejectsMissingWindowsProgramFilesWithoutMappingLibraryName()
+    {
+        AtomicBoolean mapperInvoked = new AtomicBoolean();
+
+        assertFalse(SDRPlayLibraryPathResolver.resolveWindows(null, libraryName ->
+        {
+            mapperInvoked.set(true);
+            return "sdrplay_api.dll";
+        }).isPresent());
+        assertFalse(mapperInvoked.get());
+    }
+}

--- a/src/test/java/io/github/dsheirer/stats/StatsLiveServiceBoundsTest.java
+++ b/src/test/java/io/github/dsheirer/stats/StatsLiveServiceBoundsTest.java
@@ -247,8 +247,8 @@ class StatsLiveServiceBoundsTest
 
         try
         {
-            service.start();
             source.publish(new ChannelActivityEvent(ChannelActivityEvent.Operation.UPSERT, snapshot));
+            service.start();
             byte[] withoutNavigation = service.encodedSnapshot();
             assertFalse(new String(withoutNavigation, java.nio.charset.StandardCharsets.UTF_8)
                 .contains("\"entity_ref\""));
@@ -260,8 +260,15 @@ class StatsLiveServiceBoundsTest
                     WebEntityRef.system("p25:BEE00:49F:alias-list:1"), 1, 0))));
                 catalog.refreshNow();
 
-                StatsLiveEventHub.LiveEvent resync = subscription.poll(1, TimeUnit.SECONDS);
-                assertEquals("activity_resync", resync.name(),
+                boolean resynchronized = false;
+
+                for(int index = 0; index < 3 && !resynchronized; index++)
+                {
+                    StatsLiveEventHub.LiveEvent published = subscription.poll(1, TimeUnit.SECONDS);
+                    resynchronized = published != null && "activity_resync".equals(published.name());
+                }
+
+                assertTrue(resynchronized,
                     "a catalog change must update already-connected live clients without waiting for activity");
             }
 


### PR DESCRIPTION
This addresses the Windows SDRplay loading failure reported in #53.

Alpha 11 Windows archives lost the SDRplay API search path and the Windows JIDE export, while the fallback loader checked a suffixless filename. This restores both launcher settings, resolves the actual sdrplay_api.dll name, improves load diagnostics, and verifies the finished x86-64 and ARM64 archives. The nightly workflow now builds Windows cleanly and preserves those artifacts before packaging the other platforms.

The initial CI run also exposed an existing timing race in a live-snapshot test on slower macOS and Windows runners. The follow-up test-only commit seeds its authoritative state before listeners start and uses the class existing bounded polling pattern; production stats behavior is unchanged.

Tested locally with the focused SDRplay resolver test, a full clean build (2,041 tests; 3 skipped; 0 failures), clean Windows x86-64/ARM64 packaging with finished-archive native checks, and the repaired focused live-snapshot test.