### PR TITLE
Release 0.6.2 Alpha 12

### DIFF
--- a/.github/update.properties
+++ b/.github/update.properties
@@ -2,6 +2,6 @@
 format=2
 track=alpha
 # Latest published Alpha build. Increment build for each published Alpha.
-build=6
-version=0.6.2-alpha-11
-url=https://github.com/tylerwatt12/sdrtrunk-vce/releases/tag/v0.6.2-alpha-11
+build=7
+version=0.6.2-alpha-12
+url=https://github.com/tylerwatt12/sdrtrunk-vce/releases/tag/v0.6.2-alpha-12

--- a/README.md
+++ b/README.md
@@ -224,9 +224,12 @@ Other package tasks:
 ```bash
 ./gradlew image
 ./gradlew macAppZip
-./gradlew --no-configuration-cache runtimeZipWindows
-./gradlew --no-configuration-cache runtimeZipOthers
+./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
+./gradlew --no-configuration-cache clean runtimeZipOthers -PprojectVersion=local-dev -PupdateTrack=none -PupdateBuild=0
 ```
+
+Each cross-platform package command starts from a clean build. If you are collecting every platform package, copy
+the first command's ZIP files outside `build/image` before running the second command, then restore them afterward.
 
 Build output is written under `build/image`.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ controls, long-term statistics, and performance improvements.
 
 This project has two release channels. Back up your receiver data before installing or upgrading.
 
-- [Download Alpha 11](https://github.com/tylerwatt12/sdrtrunk-vce/releases/tag/v0.6.2-alpha-11): the more stable,
+- [Download Alpha 12](https://github.com/tylerwatt12/sdrtrunk-vce/releases/tag/v0.6.2-alpha-12): the more stable,
   deliberately maintained line. Alphas receive selected fixes after review and testing and can intentionally omit
   newer Nightly features.
 - [Download the current Nightly](https://github.com/tylerwatt12/sdrtrunk-vce/releases/tag/nightly): the rolling build
@@ -33,19 +33,17 @@ This project has two release channels. Back up your receiver data before install
 - **Clear channel types:** Conventional P25, DMR, and NXDN are kept separate from trunked systems.
 - **Improved listening:** Desktop audio adds Hold, Avoid, Clear, saved mute state, a queue counter, and a queue limit.
 
-## What’s New in Alpha 11
+## What’s New in Alpha 12
 
-Alpha 11 focuses on receiver reliability and a clearer upgrade process.
+Alpha 12 is a focused repair for Windows SDRplay support and release packaging.
 
-- **USB tuner recovery is more reliable,** and the Tuners tab can rescan for reconnected devices.
-- **AM conventional decoding is restored,** with Activity, CSV, and website statistics support.
-- **RadioReference Import All** previews and imports every loaded talkgroup while preserving local choices.
-- **Alias listening uses a simple Listen setting** stored in the Default list.
-- **P25 control learning, activity, completed-call handling, and recording names are more accurate.**
-- **The Application Migrator shows progress and supports post-setup SQLite database replacement** with a safety backup
-  and validation.
+- **Windows packages again include the SDRplay API search path** used by every supported RSP model.
+- **The SDRplay fallback loader now resolves the actual `sdrplay_api.dll` filename** in the standard 64-bit API folder.
+- **Both Windows processor packages are checked before release** for the required launcher settings and Windows UI
+  classes.
+- **Other tuner implementations, decoders, and the database format are unchanged.**
 
-Read the complete [Alpha 11 What’s New](docs/whats-new-0.6.2-alpha-11.md) before upgrading.
+Read the complete [Alpha 12 What’s New](docs/whats-new-0.6.2-alpha-12.md) before upgrading.
 
 ## Screenshots
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 
 
@@ -46,7 +47,7 @@ import java.util.zip.ZipFile
  * Note: release images are located in the /build/image/ directory
  *
  * Scenario 4: create release for Windows operating system using downloaded JDK
- * command: ./gradlew runtimeZipWindows
+ * command: ./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win
  * Note: release image is located in the /build/image/ directory
  */
 plugins {
@@ -65,6 +66,17 @@ def javafxVersion = "25.0.1"
 def currentJavafxPlatform = org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.currentOperatingSystem.isWindows() ? "win" :
     (org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.currentOperatingSystem.isMacOsX() ? "mac" : "linux")
 def javafxPlatform = project.findProperty('javafxPlatform') ?: currentJavafxPlatform
+def requestedTaskNames = gradle.startParameter.taskNames.collect { taskName ->
+    taskName.tokenize(':').last()
+}
+def configurationCacheRequested = gradle.startParameter.configurationCacheRequested
+
+if(requestedTaskNames.contains('runtimeZipWindows') &&
+        (javafxPlatform != 'win' || configurationCacheRequested ||
+                requestedTaskNames != ['clean', 'runtimeZipWindows'])) {
+    throw new GradleException('runtimeZipWindows must run by itself as a clean Windows-target invocation: ' +
+            './gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win ...')
+}
 
 //JIDE 3.6.18 references the Windows look-and-feel class directly.  Non-Windows JDKs need the
 //compatibility stub, while Windows must use the real java.desktop class to avoid a split package.
@@ -481,6 +493,13 @@ test {
 }
 
 jar {
+    inputs.property('javafxPlatform', javafxPlatform)
+
+    if(javafxPlatform == 'win') {
+        //A stale non-Windows compilation must never place this compatibility class in a Windows application JAR.
+        exclude 'com/sun/java/swing/plaf/windows/WindowsLookAndFeel.class'
+    }
+
     manifest {
         attributes (
                 'Implementation-Title'  : 'sdrtrunk-vce project',
@@ -1057,6 +1076,53 @@ def windowsArchiveDescriptors = { org.beryx.runtime.RuntimeZipTask runtimeZipTas
     descriptors
 }
 
+def verifyWindowsApplicationArchive = { ZipFile zip, Map<String, Object> descriptor ->
+    String archiveRuntimeRoot = descriptor.archiveRuntimeRoot as String
+    String archiveApplicationRoot = archiveRuntimeRoot.substring(0,
+            archiveRuntimeRoot.length() - 'bin/'.length())
+    String launcherEntryName = "${archiveApplicationRoot}bin/${project.name}.bat"
+    def launcherEntry = zip.getEntry(launcherEntryName)
+
+    if(launcherEntry == null || launcherEntry.directory) {
+        throw new GradleException("Windows launcher is missing from ZIP: ${launcherEntryName}")
+    }
+
+    String launcherText
+    zip.getInputStream(launcherEntry).withCloseable { input ->
+        launcherText = input.getText('UTF-8')
+    }
+
+    [
+        '--add-exports=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED',
+        '-Djava.library.path=c:\\Program Files\\SDRplay\\API\\x64'
+    ].each { requiredArgument ->
+        if(!launcherText.contains(requiredArgument)) {
+            throw new GradleException("Windows launcher ${launcherEntryName} is missing ${requiredArgument}")
+        }
+    }
+
+    String applicationJarEntryName = "${archiveApplicationRoot}lib/${project.name}-${version}.jar"
+    def applicationJarEntry = zip.getEntry(applicationJarEntryName)
+
+    if(applicationJarEntry == null || applicationJarEntry.directory) {
+        throw new GradleException("Windows application JAR is missing from ZIP: ${applicationJarEntryName}")
+    }
+
+    String compatibilityEntryName = 'com/sun/java/swing/plaf/windows/WindowsLookAndFeel.class'
+    zip.getInputStream(applicationJarEntry).withCloseable { input ->
+        new ZipInputStream(input).withCloseable { applicationJar ->
+            def nestedEntry
+
+            while((nestedEntry = applicationJar.nextEntry) != null) {
+                if(nestedEntry.name == compatibilityEntryName) {
+                    throw new GradleException("Windows application JAR contains non-Windows compatibility class: " +
+                            compatibilityEntryName)
+                }
+            }
+        }
+    }
+}
+
 /* Verify the bytes that were actually written to each Windows archive, not only the intermediate runtime image. */
 tasks.withType(org.beryx.runtime.RuntimeZipTask).configureEach { runtimeZipTask ->
     inputs.files(providers.provider {
@@ -1078,6 +1144,8 @@ tasks.withType(org.beryx.runtime.RuntimeZipTask).configureEach { runtimeZipTask 
             ZipFile zip = new ZipFile(archive)
 
             try {
+                verifyWindowsApplicationArchive(zip, descriptor)
+
                 zip.entries().toList().findAll { entry ->
                     !entry.directory && entry.name.startsWith(archiveRuntimeRoot) &&
                         (entry.name.toLowerCase(Locale.ROOT).endsWith('.exe') ||
@@ -1271,11 +1339,14 @@ else
  *
  * Note: you cannot create both Windows and Linux releases at the same time due to limitations of the Runtime plugin
  *
- * Usage: gradle runtimeZipWindows
- * Usage: gradlew runtimeZipWindows   (windows - using gradlew)
- * Usage: ./gradlew runtimeZipWindows   (linux - using gradlew)
+ * Usage: gradle --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win
+ * Usage: gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win   (windows)
+ * Usage: ./gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win   (linux/macOS)
  */
 tasks.register('runtimeZipWindows', org.beryx.runtime.RuntimeZipTask) {rt ->
+    outputs.upToDateWhen { false }
+    mustRunAfter(tasks.named('clean'))
+
     //Windows aarch64
     if(file(jdk_windows_aarch64).exists()) {
         rt.extension.targetPlatform(targetWindowsAarch64, jdk_windows_aarch64, [])
@@ -1296,6 +1367,28 @@ tasks.register('runtimeZipWindows', org.beryx.runtime.RuntimeZipTask) {rt ->
     }
 
     configure(rt, jvmArgsWindows)
+
+    doFirst {
+        def cleanTask = tasks.named('clean').get()
+
+        if(javafxPlatform != 'win' || configurationCacheRequested ||
+                requestedTaskNames != ['clean', 'runtimeZipWindows'] ||
+                !cleanTask.state.executed || cleanTask.state.failure != null) {
+            throw new GradleException('runtimeZipWindows must run by itself as a clean Windows-target invocation: ' +
+                    './gradlew --no-configuration-cache clean runtimeZipWindows -PjavafxPlatform=win ...')
+        }
+
+        Set<String> expectedTargets = [targetWindowsAarch64, targetWindowsX86_64] as Set
+        Set<String> actualTargets = rt.extension.targetPlatforms.get().keySet() as Set
+
+        if(actualTargets != expectedTargets) {
+            throw new GradleException("runtimeZipWindows has unexpected target platforms: ${actualTargets}")
+        }
+
+        if(rt.extension.launcherData.get().jvmArgsOrDefault != jvmArgsWindows) {
+            throw new GradleException('runtimeZipWindows does not contain the required Windows launcher arguments')
+        }
+    }
 }
 
 /**

--- a/docs/whats-new-0.6.2-alpha-12.md
+++ b/docs/whats-new-0.6.2-alpha-12.md
@@ -1,0 +1,50 @@
+# What’s New in sdrtrunk-vce 0.6.2 Alpha 12
+
+## What
+
+Alpha 12 is a focused Windows packaging repair. Alpha 11’s Windows archives omitted the launcher settings needed
+to find the SDRplay API and use the native Windows look and feel. Its fallback loader also checked a filename without
+the required `.dll` suffix. Together, those defects could make an installed SDRplay tuner appear unavailable. Alpha
+12 corrects both paths and verifies the finished Windows archives before they can be released.
+
+## Added
+
+- **Windows package self-checks.** Both x86-64 and ARM64 archives must contain the SDRplay API search path and the
+  required Windows desktop export. The packaged application JAR is also checked to ensure it does not contain the
+  non-Windows compatibility class.
+
+## Changed
+
+- **Windows cross-packaging starts clean and targets Windows explicitly.** This prevents files produced for Linux or
+  macOS from being reused in a Windows archive.
+- **SDRplay load diagnostics are clearer.** The log now distinguishes a missing API file from a file that exists but
+  could not be loaded.
+
+## Fixed
+
+- **SDRplay API discovery on Windows.** The fallback loader now resolves the real mapped filename,
+  `sdrplay_api.dll`, under the standard 64-bit SDRplay API folder in Program Files.
+- **All supported SDRplay models use the repair.** The shared loader covers RSP1, RSP1A, RSP1B, RSP2, both RSPduo
+  tuners, RSPdx, and RSPdx-R2.
+- **Windows launcher consistency.** The required JIDE Windows export is restored, and Windows packages no longer
+  carry the non-Windows look-and-feel compatibility class.
+- **Other tuner implementations are unchanged.** This release does not change Airspy, HackRF, HydraSDR, or RTL-SDR
+  tuner code.
+
+## Removed
+
+- No supported features were removed in Alpha 12.
+
+## Before You Upgrade
+
+- Stop sdrtrunk-vce, back up the complete portable `data` folder, and install Alpha 12 in a new empty folder.
+- The database remains at format 2. Alpha 11 data does not need a new schema migration for this update.
+- On Windows, install the 64-bit SDRplay API in its standard Program Files location before starting sdrtrunk-vce.
+- After upgrading, confirm that each SDRplay device appears in the Tuners tab and can start normally. Also verify your
+  usual channels, recording, streaming, and website access before leaving the receiver unattended.
+- Keep Alpha 11 and its original data available for rollback until Alpha 12 has passed those checks.
+
+## Downloads
+
+Choose the download for your operating system and processor. Java 25 is included. JMBE is set up separately under
+**Preferences > Decoder > JMBE Audio Library**. Verify the ZIP’s SHA-256 checksum against `SHA256SUMS.txt`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@
 # tag name, specifically the dashes inserted before and after the alpha/beta labels.
 # See: https://github.com/DSheirer/sdrtrunk/issues/1651
 
-projectVersion=0.6.2-alpha-11
+projectVersion=0.6.2-alpha-12
 updateTrack=alpha
-updateBuild=6
+updateBuild=7
 org.gradle.configuration-cache=true

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryHelper.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryHelper.java
@@ -46,47 +46,50 @@ public class SDRPlayLibraryHelper
     private static final String SDRPLAY_API_PATH_LINUX = "/usr/local/lib/libsdrplay_api.so";
     private static final String SDRPLAY_API_PATH_MAC_OS = "/usr/local/lib/libsdrplay_api.dylib";
     private static final String SDRPLAY_API_PATH_MAC_OS_ALTERNATE = "/usr/local/lib/libsdrplay_api.so";
-    private static final String SDRPLAY_API_PATH_WINDOWS = System.getenv("ProgramFiles") +
-            "\\SDRplay\\API\\x64\\" + SDRPLAY_API_LIBRARY_NAME;
 
     public static final boolean LOADED;
     public static final boolean LOADED_FROM_PATH;
-    public static final Path LIBRARY_PATH = Path.of(getSDRplayLibraryPath());
+    public static final Path LIBRARY_PATH;
 
     static
     {
         boolean loaded = false;
         boolean loadedFromPath = false;
+        Path libraryPath = resolveSDRplayLibraryPath();
+        LIBRARY_PATH = libraryPath != null ? libraryPath : Path.of("");
 
         try
         {
             System.loadLibrary(SDRPLAY_API_LIBRARY_NAME);
-            mLog.info("SDRPLay API library loaded by name [" + SDRPLAY_API_LIBRARY_NAME + "]");
+            mLog.info("SDRPlay API library loaded by name [" + SDRPLAY_API_LIBRARY_NAME + "]");
             loaded = true;
         }
         catch(Throwable t)
         {
-            String libraryPath = getSDRplayLibraryPath();
-            Path path = Path.of(libraryPath);
-            boolean exists = Files.exists(path);
-
-            if(exists)
+            if(libraryPath != null && Files.isRegularFile(libraryPath))
             {
                 try
                 {
-                    System.load(libraryPath);
-                    mLog.info("SDRPLay API library loaded by path [" + libraryPath + "]");
+                    System.load(libraryPath.toString());
+                    mLog.info("SDRPlay API library loaded by path [" + libraryPath + "]");
                     loaded = true;
                     loadedFromPath = true;
                 }
                 catch(Throwable t2)
                 {
-                    mLog.info("SDRPlay API native library not found at " + libraryPath);
+                    mLog.warn("SDRPlay API native library was found but could not be loaded from [" + libraryPath + "]");
+                    mLog.debug("SDRPlay API native library load failure", t2);
                 }
+            }
+            else if(libraryPath != null)
+            {
+                mLog.info("SDRPlay API native library not found at: " + libraryPath);
+                mLog.debug("SDRPlay API native library was not available by name", t);
             }
             else
             {
-                mLog.info("SDRPlay API native library not found at: " + libraryPath);
+                mLog.info("SDRPlay API native library path is unavailable for this operating system");
+                mLog.debug("SDRPlay API native library was not available by name", t);
             }
         }
 
@@ -99,28 +102,37 @@ public class SDRPlayLibraryHelper
      */
     public static String getSDRplayLibraryPath()
     {
+        return LIBRARY_PATH.toString();
+    }
+
+    /**
+     * Resolves the platform-specific SDRplay native library path.
+     */
+    private static Path resolveSDRplayLibraryPath()
+    {
         if(SystemUtils.IS_OS_WINDOWS)
         {
-            return SDRPLAY_API_PATH_WINDOWS;
+            return SDRPlayLibraryPathResolver.resolveWindows(System.getenv("ProgramFiles"), System::mapLibraryName)
+                    .orElse(null);
         }
         else if(SystemUtils.IS_OS_LINUX)
         {
-            return SDRPLAY_API_PATH_LINUX;
+            return Path.of(SDRPLAY_API_PATH_LINUX);
         }
         else if(SystemUtils.IS_OS_MAC_OSX)
         {
             //API versions 3.14 and earlier used a (.so) extension and 3.15 and later use the (.dylib) extension
             if(Files.exists(Path.of(SDRPLAY_API_PATH_MAC_OS)))
             {
-                return SDRPLAY_API_PATH_MAC_OS;
+                return Path.of(SDRPLAY_API_PATH_MAC_OS);
             }
             else
             {
-                return SDRPLAY_API_PATH_MAC_OS_ALTERNATE;
+                return Path.of(SDRPLAY_API_PATH_MAC_OS_ALTERNATE);
             }
         }
 
         mLog.error("Unrecognized operating system.  Cannot identify sdrplay api library path");
-        return "";
+        return null;
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolver.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolver.java
@@ -1,0 +1,48 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Dennis Sheirer
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.source.tuner.sdrplay.api;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+/**
+ * Resolves platform-specific SDRplay API native library paths without loading the library.
+ */
+final class SDRPlayLibraryPathResolver
+{
+    private static final String SDRPLAY_API_LIBRARY_NAME = "sdrplay_api";
+
+    private SDRPlayLibraryPathResolver()
+    {
+    }
+
+    /**
+     * Resolves the installed 64-bit Windows SDRplay API library.
+     *
+     * @param programFiles Windows Program Files directory
+     * @param libraryNameMapper maps a base native library name to its platform filename
+     * @return resolved absolute library path, or empty when the installation root is unavailable
+     */
+    static Optional<Path> resolveWindows(String programFiles, UnaryOperator<String> libraryNameMapper)
+    {
+        if(programFiles == null || programFiles.isBlank())
+        {
+            return Optional.empty();
+        }
+
+        String libraryFileName = libraryNameMapper.apply(SDRPLAY_API_LIBRARY_NAME);
+
+        if(libraryFileName == null || libraryFileName.isBlank())
+        {
+            return Optional.empty();
+        }
+
+        return Optional.of(Path.of(programFiles, "SDRplay", "API", "x64", libraryFileName)
+                .toAbsolutePath().normalize());
+    }
+}

--- a/src/main/resources/release-notes/0.6.2-alpha-12.html
+++ b/src/main/resources/release-notes/0.6.2-alpha-12.html
@@ -1,0 +1,47 @@
+<h1>What’s New in sdrtrunk-vce 0.6.2 Alpha 12</h1>
+<h2>What</h2>
+<p>Alpha 12 is a focused Windows packaging repair. Alpha 11’s Windows archives omitted the launcher settings needed
+to find the SDRplay API and use the native Windows look and feel. Its fallback loader also checked a filename without
+the required <code>.dll</code> suffix. Together, those defects could make an installed SDRplay tuner appear unavailable.
+Alpha 12 corrects both paths and verifies the finished Windows archives before they can be released.</p>
+<h2>Added</h2>
+<ul>
+<li><strong>Windows package self-checks.</strong> Both x86-64 and ARM64 archives must contain the SDRplay API search path and
+the required Windows desktop export. The packaged application JAR is also checked to ensure it does not contain the
+non-Windows compatibility class.</li>
+</ul>
+<h2>Changed</h2>
+<ul>
+<li><strong>Windows cross-packaging starts clean and targets Windows explicitly.</strong> This prevents files produced for
+Linux or macOS from being reused in a Windows archive.</li>
+<li><strong>SDRplay load diagnostics are clearer.</strong> The log now distinguishes a missing API file from a file that
+exists but could not be loaded.</li>
+</ul>
+<h2>Fixed</h2>
+<ul>
+<li><strong>SDRplay API discovery on Windows.</strong> The fallback loader now resolves the real mapped filename,
+<code>sdrplay_api.dll</code>, under the standard 64-bit SDRplay API folder in Program Files.</li>
+<li><strong>All supported SDRplay models use the repair.</strong> The shared loader covers RSP1, RSP1A, RSP1B, RSP2, both
+RSPduo tuners, RSPdx, and RSPdx-R2.</li>
+<li><strong>Windows launcher consistency.</strong> The required JIDE Windows export is restored, and Windows packages no
+longer carry the non-Windows look-and-feel compatibility class.</li>
+<li><strong>Other tuner implementations are unchanged.</strong> This release does not change Airspy, HackRF, HydraSDR, or
+RTL-SDR tuner code.</li>
+</ul>
+<h2>Removed</h2>
+<ul>
+<li>No supported features were removed in Alpha 12.</li>
+</ul>
+<h2>Before You Upgrade</h2>
+<ul>
+<li>Stop sdrtrunk-vce, back up the complete portable <code>data</code> folder, and install Alpha 12 in a new empty folder.</li>
+<li>The database remains at format 2. Alpha 11 data does not need a new schema migration for this update.</li>
+<li>On Windows, install the 64-bit SDRplay API in its standard Program Files location before starting sdrtrunk-vce.</li>
+<li>After upgrading, confirm that each SDRplay device appears in the Tuners tab and can start normally. Also verify
+your usual channels, recording, streaming, and website access before leaving the receiver unattended.</li>
+<li>Keep Alpha 11 and its original data available for rollback until Alpha 12 has passed those checks.</li>
+</ul>
+<h2>Downloads</h2>
+<p>Choose the download for your operating system and processor. Java 25 is included. JMBE is set up separately under
+<strong>Preferences &gt; Decoder &gt; JMBE Audio Library</strong>. Verify the ZIP’s SHA-256 checksum against
+<code>SHA256SUMS.txt</code>.</p>

--- a/src/main/resources/release-notes/0.6.2-alpha-12.properties
+++ b/src/main/resources/release-notes/0.6.2-alpha-12.properties
@@ -1,0 +1,3 @@
+version=0.6.2-alpha-12
+title=sdrtrunk-vce 0.6.2 Alpha 12
+status=draft

--- a/src/main/resources/release-notes/0.6.2-alpha-12.properties
+++ b/src/main/resources/release-notes/0.6.2-alpha-12.properties
@@ -1,3 +1,3 @@
 version=0.6.2-alpha-12
 title=sdrtrunk-vce 0.6.2 Alpha 12
-status=draft
+status=approved

--- a/src/test/java/io/github/dsheirer/gui/whatsnew/ReleaseNotesTest.java
+++ b/src/test/java/io/github/dsheirer/gui/whatsnew/ReleaseNotesTest.java
@@ -16,11 +16,11 @@ class ReleaseNotesTest
     @Test
     void loadsVersionedRichTextDocument()
     {
-        ReleaseNotes notes = ReleaseNotes.load("0.6.2-alpha-11").orElseThrow();
+        ReleaseNotes notes = ReleaseNotes.load("0.6.2-alpha-12").orElseThrow();
 
-        assertEquals("0.6.2-alpha-11", notes.version());
-        assertEquals("sdrtrunk-vce 0.6.2 Alpha 11", notes.title());
-        assertTrue(notes.html().contains("<h1>What’s New in sdrtrunk-vce 0.6.2 Alpha 11</h1>"));
+        assertEquals("0.6.2-alpha-12", notes.version());
+        assertEquals("sdrtrunk-vce 0.6.2 Alpha 12", notes.title());
+        assertTrue(notes.html().contains("<h1>What’s New in sdrtrunk-vce 0.6.2 Alpha 12</h1>"));
     }
 
     @Test
@@ -30,14 +30,14 @@ class ReleaseNotesTest
         assertFalse(ReleaseNotes.isPublicVersion("nightly"));
         assertFalse(ReleaseNotes.isPublicVersion("0.6.2-SNAPSHOT"));
         assertFalse(ReleaseNotes.isPublicVersion("local-dev"));
-        assertTrue(ReleaseNotes.isPublicVersion("0.6.2-alpha-11"));
+        assertTrue(ReleaseNotes.isPublicVersion("0.6.2-alpha-12"));
     }
 
     @Test
     void showsOnlyWhenVersionChanges()
     {
-        assertTrue(ReleaseNotes.shouldShow("0.6.2-alpha-11", null));
-        assertTrue(ReleaseNotes.shouldShow("0.6.2-alpha-11", "0.6.2-alpha-10"));
-        assertFalse(ReleaseNotes.shouldShow("0.6.2-alpha-11", "0.6.2-alpha-11"));
+        assertTrue(ReleaseNotes.shouldShow("0.6.2-alpha-12", null));
+        assertTrue(ReleaseNotes.shouldShow("0.6.2-alpha-12", "0.6.2-alpha-11"));
+        assertFalse(ReleaseNotes.shouldShow("0.6.2-alpha-12", "0.6.2-alpha-12"));
     }
 }

--- a/src/test/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolverTest.java
+++ b/src/test/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRPlayLibraryPathResolverTest.java
@@ -1,0 +1,48 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Dennis Sheirer
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.source.tuner.sdrplay.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SDRPlayLibraryPathResolverTest
+{
+    @TempDir
+    Path mProgramFiles;
+
+    @Test
+    void resolvesMappedWindowsDllFilename()
+    {
+        Path expected = mProgramFiles.resolve("SDRplay/API/x64/sdrplay_api.dll").toAbsolutePath().normalize();
+        Path resolved = SDRPlayLibraryPathResolver.resolveWindows(mProgramFiles.toString(), libraryName ->
+        {
+            assertEquals("sdrplay_api", libraryName);
+            return "sdrplay_api.dll";
+        }).orElseThrow();
+
+        assertEquals(expected, resolved);
+        assertEquals("sdrplay_api.dll", resolved.getFileName().toString());
+    }
+
+    @Test
+    void rejectsMissingWindowsProgramFilesWithoutMappingLibraryName()
+    {
+        AtomicBoolean mapperInvoked = new AtomicBoolean();
+
+        assertFalse(SDRPlayLibraryPathResolver.resolveWindows(null, libraryName ->
+        {
+            mapperInvoked.set(true);
+            return "sdrplay_api.dll";
+        }).isPresent());
+        assertFalse(mapperInvoked.get());
+    }
+}


### PR DESCRIPTION
This prepares Alpha 12 as a focused Windows SDRplay packaging repair for the failure reported in #53. It backports the main repair with Git history preserved, adds the exact approved Alpha 12 release notes, and marks those notes approved for numbered packaging.

There is no database schema change; the database format remains 2. Other tuner implementations are unchanged.

Tested locally with the focused SDRplay resolver test, a full clean Alpha build, all seven numbered release packages, Windows finished-archive native verification, ZIP integrity checks, embedded release metadata checks, macOS app signature verification, and a SHA-256 manifest that validates every artifact.