### PR TITLE
Allow manual Alpha CI runs

### DIFF
--- a/.github/workflows/alpha-ci.yml
+++ b/.github/workflows/alpha-ci.yml
@@ -1,6 +1,7 @@
 name: Alpha CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - release/0.6.2-alpha


### PR DESCRIPTION
Alpha tags require the Alpha CI gate on the exact release-tip commit. The Alpha 12 rebase merge did not enqueue its normal push run, and this adds a manual trigger to the existing workflow so that exact tip can be tested without changing application code or release notes.

This is CI-only: there are no packaged application, database, or user-visible behavior changes. The workflow YAML also parses cleanly locally.