### PR TITLE
Reduce repeated migration test setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,7 @@ processResources {
 
 test {
     useJUnitPlatform()
+    systemProperty 'java.io.tmpdir', layout.buildDirectory.dir('tmp/test').get().asFile.absolutePath
 }
 
 dependencies {

--- a/src/main/java/io/github/dsheirer/database/SdrTrunkDatabaseBootstrap.java
+++ b/src/main/java/io/github/dsheirer/database/SdrTrunkDatabaseBootstrap.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Objects;
 
 /** Noninteractive bootstrap. Graphical orchestration belongs exclusively to SetupWizard. */
 public final class SdrTrunkDatabaseBootstrap
@@ -31,6 +32,14 @@ public final class SdrTrunkDatabaseBootstrap
     static BootstrapResult run(String[] args, Path dataRoot, boolean headless)
         throws IOException, SQLException, InterruptedException
     {
+        return run(args, dataRoot, headless, new ApplicationMigrationService());
+    }
+
+    static BootstrapResult run(String[] args, Path dataRoot, boolean headless,
+                               ApplicationMigrationService migrationService)
+        throws IOException, SQLException, InterruptedException
+    {
+        Objects.requireNonNull(migrationService, "migrationService cannot be null");
         if(!headless) throw new IOException("Use SetupWizard for graphical setup");
         if(Arrays.asList(args).contains("--setup-wizard"))
             throw new IOException("--setup-wizard requires a graphical desktop");
@@ -48,7 +57,7 @@ public final class SdrTrunkDatabaseBootstrap
                     ApplicationMigrationService.describePlan(plan) +
                     ". Start once with --upgrade-current to create a safety backup and migrate it.");
                 var approval = ApplicationMigrationService.readMigrationApproval(database, database.getParent());
-                var result = new ApplicationMigrationService().migrateCurrent(normalized, approval,
+                var result = migrationService.migrateCurrent(normalized, approval,
                     System.out::println);
                 if(!result.helperOutput().isBlank()) System.out.println(result.helperOutput());
                 if(result.safetyBackup() != null)
@@ -71,7 +80,7 @@ public final class SdrTrunkDatabaseBootstrap
             {
                 var source = PreviousBuildLocator.resolveSelection(options.upgradeData()).orElseThrow(() ->
                     new IOException("The selected location does not contain portable sdrtrunk-vce data: " + options.upgradeData()));
-                var result = new ApplicationMigrationService().importPrevious(source, normalized, System.out::println);
+                var result = migrationService.importPrevious(source, normalized, System.out::println);
                 if(!result.helperOutput().isBlank()) System.out.println(result.helperOutput());
             }
             else throw new IOException("No portable SDRTrunk database exists at " + database +

--- a/src/main/java/io/github/dsheirer/database/SdrTrunkDatabaseStartup.java
+++ b/src/main/java/io/github/dsheirer/database/SdrTrunkDatabaseStartup.java
@@ -53,24 +53,42 @@ public final class SdrTrunkDatabaseStartup
         try(Connection connection = DriverManager.getConnection("jdbc:sqlite:" + normalized))
         {
             configure(connection);
-            SdrTrunkDatabaseSchema.create(connection);
-            SdrTrunkDatabaseSchema.seedDefaultAliasLists(connection);
-            ReceiverActivitySchema.create(connection);
-            DmrActivitySchema.create(connection);
-            TrunkedSiteSchema.create(connection);
-            InitialAdminSetup.markRequired(connection);
-            io.github.dsheirer.gui.setup.SetupProgress.write(connection,
-                new io.github.dsheirer.gui.setup.SetupProgress(false, false));
-            SpectrumSnapSettings.write(connection, SpectrumSnapSettings.defaults());
-            //The whole-file marker is authoritative only after every current schema, seed row, and required
-            //fresh-profile marker has been installed successfully.
-            DatabaseFormatCatalog.stamp(connection, DatabaseFormatCatalog.CURRENT_VERSION);
-            requireMainTrackDatabase(connection);
-            SdrTrunkDatabaseSchema.validate(connection);
-            ReceiverActivitySchema.validate(connection);
-            DmrActivitySchema.validate(connection);
-            TrunkedSiteSchema.validate(connection);
-            DatabaseFormatCatalog.requireCurrent(connection);
+            connection.setAutoCommit(false);
+
+            try
+            {
+                SdrTrunkDatabaseSchema.create(connection);
+                SdrTrunkDatabaseSchema.seedDefaultAliasLists(connection);
+                ReceiverActivitySchema.create(connection);
+                DmrActivitySchema.create(connection);
+                TrunkedSiteSchema.create(connection);
+                InitialAdminSetup.markRequired(connection);
+                io.github.dsheirer.gui.setup.SetupProgress.write(connection,
+                    new io.github.dsheirer.gui.setup.SetupProgress(false, false));
+                SpectrumSnapSettings.write(connection, SpectrumSnapSettings.defaults());
+                //The whole-file marker is authoritative only after every current schema, seed row, and required
+                //fresh-profile marker has been installed successfully.
+                DatabaseFormatCatalog.stamp(connection, DatabaseFormatCatalog.CURRENT_VERSION);
+                requireMainTrackDatabase(connection);
+                SdrTrunkDatabaseSchema.validate(connection);
+                ReceiverActivitySchema.validate(connection);
+                DmrActivitySchema.validate(connection);
+                TrunkedSiteSchema.validate(connection);
+                DatabaseFormatCatalog.requireCurrent(connection);
+                connection.commit();
+            }
+            catch(SQLException | RuntimeException | Error exception)
+            {
+                try
+                {
+                    connection.rollback();
+                }
+                catch(SQLException rollbackFailure)
+                {
+                    exception.addSuppressed(rollbackFailure);
+                }
+                throw exception;
+            }
         }
     }
 

--- a/src/main/java/io/github/dsheirer/database/upgrade/ApplicationMigrationService.java
+++ b/src/main/java/io/github/dsheirer/database/upgrade/ApplicationMigrationService.java
@@ -79,6 +79,13 @@ public final class ApplicationMigrationService
             true, true);
     }
 
+    ApplicationMigrationService(MigrationRunner migrationRunner)
+    {
+        this(SqliteDatabaseSnapshot::createExternal, SqliteDatabaseSnapshot::create, migrationRunner,
+            ApplicationMigrationService::moveAtomically, ApplicationMigrationService::validateGlobalDatabase,
+            true, true);
+    }
+
     ApplicationMigrationService(Snapshotter snapshotter, MigrationRunner migrationRunner)
     {
         this(snapshotter, snapshotter, migrationRunner, ApplicationMigrationService::moveAtomically,

--- a/src/test/java/io/github/dsheirer/database/SdrTrunkDatabaseBootstrapMigrationTest.java
+++ b/src/test/java/io/github/dsheirer/database/SdrTrunkDatabaseBootstrapMigrationTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.dsheirer.database.upgrade.ApplicationMigrationService;
+import io.github.dsheirer.database.upgrade.ApplicationMigrationServiceTestSupport;
 import io.github.dsheirer.database.upgrade.DatabaseFormatCatalog;
 import io.github.dsheirer.database.upgrade.Format1TestDatabase;
 import io.github.dsheirer.database.upgrade.Format3TestDatabase;
@@ -91,7 +92,8 @@ class SdrTrunkDatabaseBootstrapMigrationTest
 
         SdrTrunkDatabaseBootstrap.BootstrapResult result =
             SdrTrunkDatabaseBootstrap.run(new String[]{"--upgrade-current", "--admin-password-file",
-                passwordFile.toString()}, dataRoot, true);
+                passwordFile.toString()}, dataRoot, true,
+                ApplicationMigrationServiceTestSupport.createInProcess());
 
         assertTrue(result.startApplication());
         assertFalse(result.initializeNewPreferences());
@@ -120,7 +122,7 @@ class SdrTrunkDatabaseBootstrapMigrationTest
 
         SdrTrunkDatabaseBootstrap.BootstrapResult result = SdrTrunkDatabaseBootstrap.run(
             new String[]{"--upgrade-data", sourceRoot.toString(), "--admin-password-file", passwordFile.toString()},
-            targetRoot, true);
+            targetRoot, true, ApplicationMigrationServiceTestSupport.createInProcess());
 
         assertTrue(result.startApplication());
         assertFalse(result.initializeNewPreferences());
@@ -151,7 +153,8 @@ class SdrTrunkDatabaseBootstrapMigrationTest
 
         SdrTrunkDatabaseBootstrap.BootstrapResult result = SdrTrunkDatabaseBootstrap.run(
             new String[]{"--upgrade-data", sourceDatabase.toString(), "--admin-password-file",
-                passwordFile.toString()}, targetRoot, true);
+                passwordFile.toString()}, targetRoot, true,
+                ApplicationMigrationServiceTestSupport.createInProcess());
 
         assertTrue(result.startApplication());
         assertFalse(result.initializeNewPreferences());
@@ -170,7 +173,7 @@ class SdrTrunkDatabaseBootstrapMigrationTest
     {
         Path dataRoot = mTemporaryFolder.resolve("current");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         removeInitialSetupMarker(database);
 
         SdrTrunkDatabaseBootstrap.BootstrapResult result =
@@ -192,7 +195,7 @@ class SdrTrunkDatabaseBootstrapMigrationTest
             Path dataRoot = mTemporaryFolder.resolve(markerPresent ?
                 "reset-invalid-admin-with-marker" : "reset-invalid-admin-without-marker");
             Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-            SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+            SdrTrunkTestDatabase.create(database);
             new WebAccessService(database).provisionOrResetPrimaryAdmin("old unusable password".toCharArray());
             try(Connection connection = open(database); Statement statement = connection.createStatement())
             {
@@ -208,7 +211,7 @@ class SdrTrunkDatabaseBootstrapMigrationTest
 
             SdrTrunkDatabaseBootstrap.BootstrapResult result = SdrTrunkDatabaseBootstrap.run(
                 new String[]{"--upgrade-current", "--admin-password-file", passwordFile.toString()},
-                dataRoot, true);
+                dataRoot, true, ApplicationMigrationServiceTestSupport.createInProcess());
 
             assertTrue(result.startApplication());
             assertEquals("complete", scalar(database, """

--- a/src/test/java/io/github/dsheirer/database/upgrade/ApplicationDatabaseMigratorTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/ApplicationDatabaseMigratorTest.java
@@ -24,6 +24,7 @@ import io.github.dsheirer.controller.channel.Channel;
 import io.github.dsheirer.database.InitialAdminSetup;
 import io.github.dsheirer.database.SdrTrunkDatabasePath;
 import io.github.dsheirer.database.SdrTrunkDatabaseStartup;
+import io.github.dsheirer.database.SdrTrunkTestDatabase;
 import io.github.dsheirer.database.SqliteSchemaValidator;
 import io.github.dsheirer.database.configuration.ConfigurationRepository;
 import io.github.dsheirer.module.decode.DecoderFactory;
@@ -57,7 +58,7 @@ class ApplicationDatabaseMigratorTest
     void validatesExactCurrentStagedDatabaseWithoutChangingSchema() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         CommandResult result = run(database);
 
@@ -85,7 +86,7 @@ class ApplicationDatabaseMigratorTest
     void repairsWrongShapePortablePreferencesInCurrentStagedDatabase() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.executeUpdate("""
@@ -109,7 +110,7 @@ class ApplicationDatabaseMigratorTest
     void normalizesCurrentPortablePreferenceStorageMetadata() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.execute("PRAGMA ignore_check_constraints=ON");
@@ -139,7 +140,7 @@ class ApplicationDatabaseMigratorTest
     void repairsPortablePreferenceComponentsIndependently() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.executeUpdate("""
@@ -186,7 +187,7 @@ class ApplicationDatabaseMigratorTest
     void repairsPreferencesBeforeAdoptingAMissingCurrentMarker() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.executeUpdate("""
@@ -221,7 +222,7 @@ class ApplicationDatabaseMigratorTest
     void repairsDamagedCurrentAdministrativeComponentsIndependently() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.execute("PRAGMA ignore_check_constraints=ON");
@@ -297,7 +298,7 @@ class ApplicationDatabaseMigratorTest
     void defaultsBrokenWebPreferencesWithoutDiscardingTheCredential() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         char[] password = "preserve this verifier".toCharArray();
         new WebAccessService(database).provisionOrResetPrimaryAdmin(password);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
@@ -330,7 +331,7 @@ class ApplicationDatabaseMigratorTest
     void resetsOnlyTheWebAccessComponentWhenThePrimaryCredentialIsUnusable() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         new WebAccessService(database).provisionOrResetPrimaryAdmin("broken verifier".toCharArray());
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -359,7 +360,7 @@ class ApplicationDatabaseMigratorTest
     void dropsOnlyCurrentAliasRoutesWhoseBroadcastProviderIsMissing() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String providerId;
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -428,7 +429,7 @@ class ApplicationDatabaseMigratorTest
     void resetsDamagedCurrentDerivedStateWithoutDiscardingAdministratorAliases() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String missingConfiguration = UUID.randomUUID().toString();
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -485,7 +486,7 @@ class ApplicationDatabaseMigratorTest
     void skipsMalformedCurrentChannelsAndProvidersWithoutLosingUsableConfiguration() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String validProviderId;
         String invalidProviderId = "00000000-0000-4000-8000-000000017501";
         String invalidChannelId = "00000000-0000-4000-8000-000000017502";
@@ -572,7 +573,7 @@ class ApplicationDatabaseMigratorTest
     void repairsCurrentAliasAndScanListNamesThatCollideAfterTrimming() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.executeUpdate("""
@@ -612,7 +613,7 @@ class ApplicationDatabaseMigratorTest
     void keepsCurrentChannelButClearsAnIncompatibleAliasListAssignment() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String configurationId;
         try(Connection connection = open(database))
         {
@@ -682,7 +683,7 @@ class ApplicationDatabaseMigratorTest
     void adoptsMarkerForExactMarkerlessCurrentLayout() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database); var statement = connection.prepareStatement(
             "DELETE FROM database_metadata WHERE key=?"))
@@ -704,7 +705,7 @@ class ApplicationDatabaseMigratorTest
     void repairsRetiredMetadataBeforeAdoptingAMissingCurrentMarker() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -817,7 +818,7 @@ class ApplicationDatabaseMigratorTest
     void leavesReusableFreePagesInsteadOfRunningRiskyMigrationTimeCompaction() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -1212,7 +1213,7 @@ class ApplicationDatabaseMigratorTest
         }
 
         Path exactCurrent = mTemporaryFolder.resolve("exact-current.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(exactCurrent);
+        SdrTrunkTestDatabase.create(exactCurrent);
         try(Connection migrated = open(database); Connection current = open(exactCurrent))
         {
             assertEquals(SqliteSchemaValidator.fingerprint(current), SqliteSchemaValidator.fingerprint(migrated),
@@ -1369,7 +1370,7 @@ class ApplicationDatabaseMigratorTest
     void rebasesPortableDirectoriesWithoutChangingSchema() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         Path source = mTemporaryFolder.resolve("source-data").toAbsolutePath();
         Path target = mTemporaryFolder.resolve("target-data").toAbsolutePath();
 
@@ -1427,7 +1428,7 @@ class ApplicationDatabaseMigratorTest
     void dropsOnlyAPathWhoseLongerRelocationWouldOverflowPortablePreferences() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         Path source = mTemporaryFolder.resolve("source").toAbsolutePath();
         Path target = mTemporaryFolder.resolve("target".repeat(512)).toAbsolutePath();
 
@@ -1469,7 +1470,7 @@ class ApplicationDatabaseMigratorTest
     void refusesIncompleteCurrentSchemaWithoutRepairingIt() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -1515,7 +1516,7 @@ class ApplicationDatabaseMigratorTest
     void malformedCurrentPortablePreferencesAreResetWithoutBlockingMigration() throws Exception
     {
         Path database = newStagedDatabase();
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         Path source = mTemporaryFolder.resolve("source-data").toAbsolutePath();
         Path target = mTemporaryFolder.resolve("target-data").toAbsolutePath();
 
@@ -1591,7 +1592,7 @@ class ApplicationDatabaseMigratorTest
     {
         Path dataRoot = mTemporaryFolder.resolve("live-data");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         byte[] before = Files.readAllBytes(database);
 
         CommandResult result = runArguments(database.toString());
@@ -1606,7 +1607,7 @@ class ApplicationDatabaseMigratorTest
     {
         Path dataRoot = mTemporaryFolder.resolve("live-symlink-data");
         Path liveDatabase = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(liveDatabase);
+        SdrTrunkTestDatabase.create(liveDatabase);
         byte[] before = Files.readAllBytes(liveDatabase);
         Path stagedLink = newStagedDatabase();
 
@@ -1631,7 +1632,7 @@ class ApplicationDatabaseMigratorTest
     {
         Path dataRoot = mTemporaryFolder.resolve("live-ancestor-data");
         Path liveDatabase = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(liveDatabase);
+        SdrTrunkTestDatabase.create(liveDatabase);
         byte[] before = Files.readAllBytes(liveDatabase);
         Path deceptiveStageRoot = mTemporaryFolder.resolve(".live-ancestor-data.migration-" + UUID.randomUUID());
 
@@ -1658,7 +1659,7 @@ class ApplicationDatabaseMigratorTest
     {
         Path dataRoot = mTemporaryFolder.resolve("live-hard-link-data");
         Path liveDatabase = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(liveDatabase);
+        SdrTrunkTestDatabase.create(liveDatabase);
         byte[] before = Files.readAllBytes(liveDatabase);
         Path stagedLink = newStagedDatabase();
 

--- a/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTest.java
@@ -29,10 +29,7 @@ import io.github.dsheirer.preference.encryption.vault.EncryptionKeyVaultSchema;
 import io.github.dsheirer.source.config.SourceConfigTuner;
 import io.github.dsheirer.stats.activity.DmrActivitySchema;
 import io.github.dsheirer.web.auth.WebAccessService;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
@@ -1255,7 +1252,7 @@ class ApplicationMigrationServiceTest
             ApplicationMigrationService.readMigrationApproval(database);
         ApplicationMigrationService service = new ApplicationMigrationService(
             SqliteDatabaseSnapshot::create,
-            ApplicationMigrationServiceTest::runMigratorInProcess,
+            ApplicationMigrationServiceTestSupport::runMigratorInProcess,
             promoted ->
             {
                 throw new SQLException("forced post-promotion validation failure");
@@ -1423,7 +1420,7 @@ class ApplicationMigrationServiceTest
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = Files.createDirectory(mTemporaryFolder.resolve("atomic-promotion-target"));
         ApplicationMigrationService service = new ApplicationMigrationService(SqliteDatabaseSnapshot::create,
-            ApplicationMigrationServiceTest::runMigratorInProcess,
+            ApplicationMigrationServiceTestSupport::runMigratorInProcess,
             (staged, target) ->
             {
                 assertFalse(Files.exists(target));
@@ -1502,30 +1499,7 @@ class ApplicationMigrationServiceTest
 
     private static ApplicationMigrationService inProcessMigrationService()
     {
-        return new ApplicationMigrationService(ApplicationMigrationServiceTest::runMigratorInProcess);
-    }
-
-    private static String runMigratorInProcess(Path stagedDatabase, Path sourceDataRoot, Path targetDataRoot)
-        throws IOException
-    {
-        String[] arguments = sourceDataRoot == null ? new String[] {stagedDatabase.toString()} :
-            new String[] {stagedDatabase.toString(), sourceDataRoot.toString(), targetDataRoot.toString()};
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-
-        try(PrintStream output = new PrintStream(captured, true, StandardCharsets.UTF_8))
-        {
-            int exitCode = ApplicationDatabaseMigrator.run(arguments, output, output);
-            output.flush();
-            String report = captured.toString(StandardCharsets.UTF_8).trim();
-
-            if(exitCode != ApplicationDatabaseMigrator.EXIT_SUCCESS)
-            {
-                throw new IOException("The in-process Application Migrator failed with exit code " + exitCode +
-                    (report.isBlank() ? "." : ":\n" + report));
-            }
-
-            return report;
-        }
+        return ApplicationMigrationServiceTestSupport.createInProcess();
     }
 
     private static void insertAlias(Path database, String name) throws Exception

--- a/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.dsheirer.controller.channel.Channel;
 import io.github.dsheirer.database.SdrTrunkDatabasePath;
-import io.github.dsheirer.database.SdrTrunkDatabaseStartup;
+import io.github.dsheirer.database.SdrTrunkTestDatabase;
 import io.github.dsheirer.module.decode.DecoderFactory;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.preference.encryption.vault.EncryptionKeyVaultPath;
@@ -29,7 +29,10 @@ import io.github.dsheirer.preference.encryption.vault.EncryptionKeyVaultSchema;
 import io.github.dsheirer.source.config.SourceConfigTuner;
 import io.github.dsheirer.stats.activity.DmrActivitySchema;
 import io.github.dsheirer.web.auth.WebAccessService;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
@@ -95,7 +98,7 @@ class ApplicationMigrationServiceTest
             .anyMatch(effect -> "per-user idle FFT channel markers".equals(effect.subject())));
 
         Path currentDatabase = SdrTrunkDatabasePath.getDatabasePath(mTemporaryFolder.resolve("current-plan"));
-        SdrTrunkDatabaseStartup.createGlobalDatabase(currentDatabase);
+        SdrTrunkTestDatabase.create(currentDatabase);
         DatabaseMigrationChain.PreflightReport currentPlan =
             ApplicationMigrationService.readMigrationPlan(currentDatabase);
         assertFormat(currentPlan.source(), DatabaseFormatCatalog.CURRENT_VERSION,
@@ -137,7 +140,7 @@ class ApplicationMigrationServiceTest
         insertAlias(database, "Retained Format 1 Alias");
 
         ApplicationMigrationService.MigrationResult result =
-            new ApplicationMigrationService().migrateCurrent(dataRoot, null);
+            inProcessMigrationService().migrateCurrent(dataRoot, null);
 
         assertFalse(result.importedPreviousProfile());
         assertFormat(result.sourceFormat(), 1, "alpha8-shared", false);
@@ -210,7 +213,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("invalid-optional-vault-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         Path sourceVault = EncryptionKeyVaultPath.getVaultPath(sourceRoot);
         Files.createDirectories(sourceVault.getParent());
         String secret = "DO-NOT-REPORT-vault-secret";
@@ -242,7 +245,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("unsupported-vault-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         Path sourceVault = createValidVault(sourceRoot);
         try(Connection connection = DriverManager.getConnection("jdbc:sqlite:" + sourceVault);
             Statement statement = connection.createStatement())
@@ -269,7 +272,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("optional-symlink-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         Path privateFile = mTemporaryFolder.resolve("private-api-key-material.jar");
         String secret = "DO-NOT-REPORT-symlink-secret";
         Files.writeString(privateFile, secret);
@@ -310,7 +313,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("optional-unreadable-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         Path sourceJmbe = Files.createDirectories(sourceRoot.resolve("jmbe")).resolve("jmbe.jar");
         Files.writeString(sourceJmbe, "jmbe-content");
         Path unreadable = Files.createDirectories(sourceRoot.resolve("modules")).resolve("private-module.jar");
@@ -351,7 +354,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("mandatory-snapshot-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("mandatory-snapshot-target");
         AtomicBoolean helperRan = new AtomicBoolean();
@@ -385,7 +388,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("database-only-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         insertAlias(sourceDatabase, "Database Only Alias");
         byte[] sourceHash = sha256(sourceDatabase);
         Files.createDirectories(sourceRoot.resolve("jmbe"));
@@ -436,7 +439,7 @@ class ApplicationMigrationServiceTest
     {
         Path activeRoot = mTemporaryFolder.resolve("active-replacement-data");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
         insertAlias(activeDatabase, "Previous Active Alias");
         Path retainedJmbe = Files.createDirectories(activeRoot.resolve("jmbe")).resolve("retained.jar");
         Files.writeString(retainedJmbe, "keep current external file");
@@ -482,13 +485,13 @@ class ApplicationMigrationServiceTest
         Path activeRoot = mTemporaryFolder.resolve("review-target");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
         Path sourceDatabase = mTemporaryFolder.resolve("review-source.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         new io.github.dsheirer.gui.setup.SetupProgress(true, false).save(sourceDatabase);
         insertAlias(activeDatabase, "Old destination");
         insertAlias(sourceDatabase, "Selected source");
         byte[] sourceHash = sha256(sourceDatabase);
-        var result = new ApplicationMigrationService().replaceCurrentDatabase(sourceDatabase, activeRoot, null);
+        var result = inProcessMigrationService().replaceCurrentDatabase(sourceDatabase, activeRoot, null);
         assertCurrentFormat(activeDatabase);
         assertArrayEquals(sourceHash, sha256(sourceDatabase));
         var review = io.github.dsheirer.gui.setup.SetupProgress.read(activeDatabase);
@@ -506,20 +509,20 @@ class ApplicationMigrationServiceTest
     {
         Path activeRoot = mTemporaryFolder.resolve("active-plan-binding-data");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
         insertAlias(activeDatabase, "Keep Active");
         byte[] activeHash = sha256(activeDatabase);
 
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(
             mTemporaryFolder.resolve("selected-plan-binding-source"));
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         ApplicationMigrationService.ApprovedMigrationPlan approved =
             ApplicationMigrationService.readMigrationApproval(sourceDatabase);
         Files.delete(sourceDatabase);
         Format14TestDatabase.create(sourceDatabase);
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().replaceCurrentDatabase(sourceDatabase, activeRoot, approved,
+            () -> inProcessMigrationService().replaceCurrentDatabase(sourceDatabase, activeRoot, approved,
                 null));
 
         assertTrue(exception.getMessage().contains("SQLite database selected after confirmation"));
@@ -533,7 +536,7 @@ class ApplicationMigrationServiceTest
     {
         Path activeRoot = mTemporaryFolder.resolve("active-admin-replacement-data");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
 
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(
             mTemporaryFolder.resolve("selected-admin-source"));
@@ -541,7 +544,7 @@ class ApplicationMigrationServiceTest
         char[] password = "retained alpha administrator".toCharArray();
         LegacyWebAccessTestData.storePrimaryAdmin(sourceDatabase, password);
 
-        new ApplicationMigrationService().replaceCurrentDatabase(sourceDatabase, activeRoot, null);
+        inProcessMigrationService().replaceCurrentDatabase(sourceDatabase, activeRoot, null);
 
         assertEquals("complete", scalar(activeDatabase, """
             SELECT value FROM database_metadata WHERE key='initial_admin_setup'
@@ -554,7 +557,7 @@ class ApplicationMigrationServiceTest
     {
         Path activeRoot = mTemporaryFolder.resolve("active-helper-failure-data");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
         insertAlias(activeDatabase, "Still Active");
         byte[] activeHash = sha256(activeDatabase);
 
@@ -600,10 +603,10 @@ class ApplicationMigrationServiceTest
     {
         Path activeRoot = mTemporaryFolder.resolve("same-replacement-data");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().replaceCurrentDatabase(activeDatabase, activeRoot, null));
+            () -> inProcessMigrationService().replaceCurrentDatabase(activeDatabase, activeRoot, null));
 
         assertTrue(exception.getMessage().contains("paths are the same"));
         assertFalse(Files.exists(activeDatabase.getParent().resolve("backups")));
@@ -614,7 +617,7 @@ class ApplicationMigrationServiceTest
     {
         Path activeRoot = mTemporaryFolder.resolve("hard-link-replacement-data");
         Path activeDatabase = SdrTrunkDatabasePath.getDatabasePath(activeRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(activeDatabase);
+        SdrTrunkTestDatabase.create(activeDatabase);
         Path hardLink = mTemporaryFolder.resolve("active-database-hard-link.sqlite");
         try
         {
@@ -626,7 +629,7 @@ class ApplicationMigrationServiceTest
         }
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().replaceCurrentDatabase(hardLink, activeRoot, null));
+            () -> inProcessMigrationService().replaceCurrentDatabase(hardLink, activeRoot, null));
 
         assertTrue(exception.getMessage().contains("same physical file"));
         assertFalse(Files.exists(activeDatabase.getParent().resolve("backups")));
@@ -637,12 +640,12 @@ class ApplicationMigrationServiceTest
     {
         Path outerSource = mTemporaryFolder.resolve("outer-source");
         Path outerSourceDatabase = SdrTrunkDatabasePath.getDatabasePath(outerSource);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(outerSourceDatabase);
+        SdrTrunkTestDatabase.create(outerSourceDatabase);
         byte[] outerSourceHash = sha256(outerSourceDatabase);
         Path nestedTarget = outerSource.resolve("jmbe/imported-data");
 
         IOException nestedTargetException = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(outerSource, nestedTarget, null));
+            () -> inProcessMigrationService().importPrevious(outerSource, nestedTarget, null));
 
         assertTrue(nestedTargetException.getMessage().contains("overlap"));
         assertArrayEquals(outerSourceHash, sha256(outerSourceDatabase));
@@ -651,11 +654,11 @@ class ApplicationMigrationServiceTest
         Path outerTarget = mTemporaryFolder.resolve("outer-target");
         Path nestedSource = outerTarget.resolve("previous-data");
         Path nestedSourceDatabase = SdrTrunkDatabasePath.getDatabasePath(nestedSource);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(nestedSourceDatabase);
+        SdrTrunkTestDatabase.create(nestedSourceDatabase);
         byte[] nestedSourceHash = sha256(nestedSourceDatabase);
 
         IOException nestedSourceException = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(nestedSource, outerTarget, null));
+            () -> inProcessMigrationService().importPrevious(nestedSource, outerTarget, null));
 
         assertTrue(nestedSourceException.getMessage().contains("overlap"));
         assertArrayEquals(nestedSourceHash, sha256(nestedSourceDatabase));
@@ -667,7 +670,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("plan-change-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("plan-change-target");
         AtomicBoolean helperRan = new AtomicBoolean();
@@ -704,7 +707,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("approved-plan-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         ApplicationMigrationService.ApprovedMigrationPlan approvedPlan =
             ApplicationMigrationService.readMigrationApproval(sourceDatabase);
 
@@ -716,7 +719,7 @@ class ApplicationMigrationServiceTest
             PreviousBuildLocator.InputScope.PORTABLE_PROFILE);
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(selection, targetRoot, approvedPlan, null));
+            () -> inProcessMigrationService().importPrevious(selection, targetRoot, approvedPlan, null));
 
         assertTrue(exception.getMessage().contains("source database selected after confirmation"));
         assertFalse(Files.exists(targetRoot));
@@ -726,7 +729,7 @@ class ApplicationMigrationServiceTest
     void refusesChangedSourceContentEvenWhenTheReviewedPlanIsUnchanged() throws Exception
     {
         Path sourceDatabase = mTemporaryFolder.resolve("same-plan-changed-source.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         insertAlias(sourceDatabase, "Approved Alias Name");
         ApplicationMigrationService.ApprovedMigrationPlan approved =
             ApplicationMigrationService.readMigrationApproval(sourceDatabase);
@@ -744,7 +747,7 @@ class ApplicationMigrationServiceTest
             PreviousBuildLocator.InputScope.DATABASE_FILE);
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(selection, targetRoot, approved, null));
+            () -> inProcessMigrationService().importPrevious(selection, targetRoot, approved, null));
 
         assertTrue(exception.getMessage().contains("database content may have changed"));
         assertFalse(Files.exists(targetRoot));
@@ -754,7 +757,7 @@ class ApplicationMigrationServiceTest
     void approvalPreflightIncludesCommittedWalContent() throws Exception
     {
         Path sourceDatabase = mTemporaryFolder.resolve("approval-wal-source.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         insertAlias(sourceDatabase, "Alias With WAL Route");
 
         try(Connection writer = open(sourceDatabase); Statement statement = writer.createStatement())
@@ -785,7 +788,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("foreign-key-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
 
         try(Connection connection = open(sourceDatabase); Statement statement = connection.createStatement())
         {
@@ -799,7 +802,7 @@ class ApplicationMigrationServiceTest
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("foreign-key-target");
 
-        ApplicationMigrationService.MigrationResult result = new ApplicationMigrationService()
+        ApplicationMigrationService.MigrationResult result = inProcessMigrationService()
             .importPrevious(sourceRoot, targetRoot, null);
 
         assertTrue(result.importedPreviousProfile());
@@ -818,7 +821,7 @@ class ApplicationMigrationServiceTest
     {
         Path database = SdrTrunkDatabasePath.getDatabasePath(
             mTemporaryFolder.resolve("markerless-current-foreign-key-source"));
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
@@ -862,7 +865,7 @@ class ApplicationMigrationServiceTest
         assertEquals(2, plan.source().version());
         Path targetRoot = Files.createDirectory(mTemporaryFolder.resolve("legacy-foreign-key-target"));
 
-        ApplicationMigrationService.MigrationResult result = new ApplicationMigrationService()
+        ApplicationMigrationService.MigrationResult result = inProcessMigrationService()
             .importPrevious(sourceRoot, targetRoot, null);
 
         assertTrue(result.importedPreviousProfile());
@@ -898,7 +901,7 @@ class ApplicationMigrationServiceTest
 
         PreviousBuildLocator.Selection selection = new PreviousBuildLocator.Selection(sourceRoot,
             PreviousBuildLocator.InputScope.PORTABLE_PROFILE);
-        new ApplicationMigrationService().importPrevious(selection, targetRoot, approval, null);
+        inProcessMigrationService().importPrevious(selection, targetRoot, approval, null);
 
         Path targetDatabase = SdrTrunkDatabasePath.getDatabasePath(targetRoot);
         assertCurrentFormat(targetDatabase);
@@ -923,7 +926,7 @@ class ApplicationMigrationServiceTest
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("format14-exhausted-preference-target");
 
-        ApplicationMigrationService.MigrationResult result = new ApplicationMigrationService()
+        ApplicationMigrationService.MigrationResult result = inProcessMigrationService()
             .importPrevious(sourceRoot, targetRoot, null);
 
         Path targetDatabase = SdrTrunkDatabasePath.getDatabasePath(targetRoot);
@@ -943,7 +946,7 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("current-state");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         DatabaseMigrationChain.PreflightReport plan = ApplicationMigrationService.readMigrationPlan(database);
 
@@ -957,7 +960,7 @@ class ApplicationMigrationServiceTest
     void approvalUsesAndCleansTheCallerSelectedScratchVolume() throws Exception
     {
         Path database = SdrTrunkDatabasePath.getDatabasePath(mTemporaryFolder.resolve("approval-source"));
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         Path scratch = mTemporaryFolder.resolve("destination-adjacent-scratch");
 
         ApplicationMigrationService.ApprovedMigrationPlan approval =
@@ -976,7 +979,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("repairable-current-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         try(Connection connection = open(sourceDatabase); Statement statement = connection.createStatement())
         {
             statement.execute("PRAGMA ignore_check_constraints=ON");
@@ -1004,7 +1007,7 @@ class ApplicationMigrationServiceTest
         ApplicationMigrationService.ApprovedMigrationPlan approval =
             ApplicationMigrationService.readMigrationApproval(sourceDatabase);
         assertEquals(plan, approval.plan());
-        ApplicationMigrationService.MigrationResult result = new ApplicationMigrationService().importPrevious(
+        ApplicationMigrationService.MigrationResult result = inProcessMigrationService().importPrevious(
             new PreviousBuildLocator.Selection(sourceDatabase, PreviousBuildLocator.InputScope.DATABASE_FILE),
             targetRoot, approval, null);
 
@@ -1023,14 +1026,14 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("source-data");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         insertAlias(sourceDatabase, "Keep Me");
         insertCurrentProfileSentinels(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("target-data");
         Files.createDirectory(targetRoot);
 
-        ApplicationMigrationService.MigrationResult result = new ApplicationMigrationService()
+        ApplicationMigrationService.MigrationResult result = inProcessMigrationService()
             .importPrevious(sourceRoot, targetRoot, null);
 
         assertTrue(result.importedPreviousProfile());
@@ -1057,11 +1060,11 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("current-data");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         insertAlias(database, "Retained");
 
         ApplicationMigrationService.MigrationResult result =
-            new ApplicationMigrationService().migrateCurrent(dataRoot, null);
+            inProcessMigrationService().migrateCurrent(dataRoot, null);
 
         assertFalse(result.importedPreviousProfile());
         assertNotNull(result.safetyBackup());
@@ -1078,14 +1081,14 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("posix-current-data");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         PosixFileAttributeView view = Files.getFileAttributeView(database, PosixFileAttributeView.class);
         Assumptions.assumeTrue(view != null, "POSIX file attributes are unavailable");
         view.setPermissions(PosixFilePermissions.fromString("rw-------"));
         PosixFileAttributes before = view.readAttributes();
 
         ApplicationMigrationService.MigrationResult result =
-            new ApplicationMigrationService().migrateCurrent(dataRoot, null);
+            inProcessMigrationService().migrateCurrent(dataRoot, null);
 
         PosixFileAttributes after = Files.readAttributes(database, PosixFileAttributes.class);
         assertEquals(before.permissions(), after.permissions());
@@ -1101,14 +1104,14 @@ class ApplicationMigrationServiceTest
     void profileImportPreservesAnExistingEmptyTargetRootsPosixAccess() throws Exception
     {
         Path sourceRoot = mTemporaryFolder.resolve("posix-import-source");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(SdrTrunkDatabasePath.getDatabasePath(sourceRoot));
+        SdrTrunkTestDatabase.create(SdrTrunkDatabasePath.getDatabasePath(sourceRoot));
         Path targetRoot = Files.createDirectory(mTemporaryFolder.resolve("posix-import-target"));
         PosixFileAttributeView view = Files.getFileAttributeView(targetRoot, PosixFileAttributeView.class);
         Assumptions.assumeTrue(view != null, "POSIX file attributes are unavailable");
         view.setPermissions(PosixFilePermissions.fromString("rwx------"));
         PosixFileAttributes before = view.readAttributes();
 
-        new ApplicationMigrationService().importPrevious(sourceRoot, targetRoot, null);
+        inProcessMigrationService().importPrevious(sourceRoot, targetRoot, null);
 
         PosixFileAttributes after = Files.readAttributes(targetRoot, PosixFileAttributes.class);
         assertEquals(before.permissions(), after.permissions());
@@ -1121,12 +1124,12 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("pre-release-data");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         removeDmrActivitySchema(database);
         byte[] before = sha256(database);
 
         SQLException exception = assertThrows(SQLException.class,
-            () -> new ApplicationMigrationService().migrateCurrent(dataRoot, null));
+            () -> inProcessMigrationService().migrateCurrent(dataRoot, null));
 
         assertTrue(exception.getMessage().contains("Unrecognized SQLite database schema fingerprint"));
         assertArrayEquals(before, sha256(database));
@@ -1138,7 +1141,7 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("current-recorded-call-source");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.executeUpdate("CREATE TABLE recorded_call_private_payload(id INTEGER PRIMARY KEY)");
@@ -1147,13 +1150,13 @@ class ApplicationMigrationServiceTest
         Path targetRoot = mTemporaryFolder.resolve("current-recorded-call-target");
 
         SQLException importFailure = assertThrows(SQLException.class,
-            () -> new ApplicationMigrationService().importPrevious(dataRoot, targetRoot, null));
+            () -> inProcessMigrationService().importPrevious(dataRoot, targetRoot, null));
         assertTrue(importFailure.getMessage().contains("webfirst managed-recording"));
         assertFalse(Files.exists(targetRoot));
         assertArrayEquals(before, sha256(database));
 
         SQLException currentFailure = assertThrows(SQLException.class,
-            () -> new ApplicationMigrationService().migrateCurrent(dataRoot, null));
+            () -> inProcessMigrationService().migrateCurrent(dataRoot, null));
         assertTrue(currentFailure.getMessage().contains("webfirst managed-recording"));
         assertFalse(Files.exists(database.getParent().resolve("backups")));
         assertArrayEquals(before, sha256(database));
@@ -1164,7 +1167,7 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("failure-data");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         insertAlias(database, "Do Not Lose");
         byte[] before = sha256(database);
         AtomicReference<Path> stagedDatabase = new AtomicReference<>();
@@ -1199,7 +1202,7 @@ class ApplicationMigrationServiceTest
         }
 
         ApplicationMigrationService.MigrationResult retry =
-            new ApplicationMigrationService().migrateCurrent(dataRoot, null);
+            inProcessMigrationService().migrateCurrent(dataRoot, null);
         assertNotNull(retry.safetyBackup());
         assertCurrentFormat(database);
         assertEquals(1, count(database, "alias"));
@@ -1210,7 +1213,7 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("uncertain-live-database");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         insertAlias(database, "Retained Safety Backup Alias");
         Path sidecar = Path.of(database + "-wal");
         ApplicationMigrationService service = new ApplicationMigrationService(
@@ -1252,7 +1255,7 @@ class ApplicationMigrationServiceTest
             ApplicationMigrationService.readMigrationApproval(database);
         ApplicationMigrationService service = new ApplicationMigrationService(
             SqliteDatabaseSnapshot::create,
-            ApplicationMigratorLauncher::run,
+            ApplicationMigrationServiceTest::runMigratorInProcess,
             promoted ->
             {
                 throw new SQLException("forced post-promotion validation failure");
@@ -1279,7 +1282,7 @@ class ApplicationMigrationServiceTest
     {
         Path dataRoot = mTemporaryFolder.resolve("snapshot-failure-data");
         Path database = SdrTrunkDatabasePath.getDatabasePath(dataRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         byte[] before = sha256(database);
         ApplicationMigrationService service = new ApplicationMigrationService(
             (source, destination) ->
@@ -1308,7 +1311,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("source-main-data");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("target-main-data");
         ApplicationMigrationService service = new ApplicationMigrationService(
@@ -1344,7 +1347,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("invalid-config-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         insertCurrentProfileSentinels(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = mTemporaryFolder.resolve("invalid-config-target");
@@ -1380,13 +1383,13 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("promotion-race-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = Files.createDirectory(mTemporaryFolder.resolve("promotion-race-target"));
         Path competingFile = targetRoot.resolve("created-by-another-first-run.txt");
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(sourceRoot, targetRoot, progress ->
+            () -> inProcessMigrationService().importPrevious(sourceRoot, targetRoot, progress ->
             {
                 if("Finishing".equals(progress))
                 {
@@ -1416,11 +1419,11 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("atomic-promotion-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path targetRoot = Files.createDirectory(mTemporaryFolder.resolve("atomic-promotion-target"));
         ApplicationMigrationService service = new ApplicationMigrationService(SqliteDatabaseSnapshot::create,
-            ApplicationMigratorLauncher::run,
+            ApplicationMigrationServiceTest::runMigratorInProcess,
             (staged, target) ->
             {
                 assertFalse(Files.exists(target));
@@ -1449,7 +1452,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("physical-source");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path sourceLink = mTemporaryFolder.resolve("source-link");
         try
@@ -1463,7 +1466,7 @@ class ApplicationMigrationServiceTest
         Path apparentlySeparateTarget = sourceLink.resolve("jmbe/imported-data");
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(sourceRoot, apparentlySeparateTarget, null));
+            () -> inProcessMigrationService().importPrevious(sourceRoot, apparentlySeparateTarget, null));
 
         assertTrue(exception.getMessage().contains("overlap"));
         assertArrayEquals(sourceHash, sha256(sourceDatabase));
@@ -1475,7 +1478,7 @@ class ApplicationMigrationServiceTest
     {
         Path sourceRoot = mTemporaryFolder.resolve("source-with-target-link");
         Path sourceDatabase = SdrTrunkDatabasePath.getDatabasePath(sourceRoot);
-        SdrTrunkDatabaseStartup.createGlobalDatabase(sourceDatabase);
+        SdrTrunkTestDatabase.create(sourceDatabase);
         byte[] sourceHash = sha256(sourceDatabase);
         Path installParent = Files.createDirectories(sourceRoot.resolve("jmbe"));
         Path externalEmptyDirectory = Files.createDirectories(mTemporaryFolder.resolve("external-empty"));
@@ -1490,11 +1493,40 @@ class ApplicationMigrationServiceTest
         }
 
         IOException exception = assertThrows(IOException.class,
-            () -> new ApplicationMigrationService().importPrevious(sourceRoot, targetLink, null));
+            () -> inProcessMigrationService().importPrevious(sourceRoot, targetLink, null));
 
         assertTrue(exception.getMessage().contains("overlap"));
         assertArrayEquals(sourceHash, sha256(sourceDatabase));
         assertTrue(Files.isSymbolicLink(targetLink));
+    }
+
+    private static ApplicationMigrationService inProcessMigrationService()
+    {
+        return new ApplicationMigrationService(SqliteDatabaseSnapshot::create,
+            ApplicationMigrationServiceTest::runMigratorInProcess);
+    }
+
+    private static String runMigratorInProcess(Path stagedDatabase, Path sourceDataRoot, Path targetDataRoot)
+        throws IOException
+    {
+        String[] arguments = sourceDataRoot == null ? new String[] {stagedDatabase.toString()} :
+            new String[] {stagedDatabase.toString(), sourceDataRoot.toString(), targetDataRoot.toString()};
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+
+        try(PrintStream output = new PrintStream(captured, true, StandardCharsets.UTF_8))
+        {
+            int exitCode = ApplicationDatabaseMigrator.run(arguments, output, output);
+            output.flush();
+            String report = captured.toString(StandardCharsets.UTF_8).trim();
+
+            if(exitCode != ApplicationDatabaseMigrator.EXIT_SUCCESS)
+            {
+                throw new IOException("The in-process Application Migrator failed with exit code " + exitCode +
+                    (report.isBlank() ? "." : ":\n" + report));
+            }
+
+            return report;
+        }
     }
 
     private static void insertAlias(Path database, String name) throws Exception

--- a/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTest.java
@@ -1502,8 +1502,7 @@ class ApplicationMigrationServiceTest
 
     private static ApplicationMigrationService inProcessMigrationService()
     {
-        return new ApplicationMigrationService(SqliteDatabaseSnapshot::create,
-            ApplicationMigrationServiceTest::runMigratorInProcess);
+        return new ApplicationMigrationService(ApplicationMigrationServiceTest::runMigratorInProcess);
     }
 
     private static String runMigratorInProcess(Path stagedDatabase, Path sourceDataRoot, Path targetDataRoot)

--- a/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTestSupport.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/ApplicationMigrationServiceTestSupport.java
@@ -1,0 +1,48 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2026 Dennis Sheirer
+ * ****************************************************************************
+ */
+package io.github.dsheirer.database.upgrade;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+/** Shared in-process Application Migrator support for orchestration tests. */
+public final class ApplicationMigrationServiceTestSupport
+{
+    private ApplicationMigrationServiceTestSupport()
+    {
+    }
+
+    public static ApplicationMigrationService createInProcess()
+    {
+        return new ApplicationMigrationService(ApplicationMigrationServiceTestSupport::runMigratorInProcess);
+    }
+
+    static String runMigratorInProcess(Path stagedDatabase, Path sourceDataRoot, Path targetDataRoot)
+        throws IOException
+    {
+        String[] arguments = sourceDataRoot == null ? new String[] {stagedDatabase.toString()} :
+            new String[] {stagedDatabase.toString(), sourceDataRoot.toString(), targetDataRoot.toString()};
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+
+        try(PrintStream output = new PrintStream(captured, true, StandardCharsets.UTF_8))
+        {
+            int exitCode = ApplicationDatabaseMigrator.run(arguments, output, output);
+            output.flush();
+            String report = captured.toString(StandardCharsets.UTF_8).trim();
+
+            if(exitCode != ApplicationDatabaseMigrator.EXIT_SUCCESS)
+            {
+                throw new IOException("The in-process Application Migrator failed with exit code " + exitCode +
+                    (report.isBlank() ? "." : ":\n" + report));
+            }
+
+            return report;
+        }
+    }
+}

--- a/src/test/java/io/github/dsheirer/database/upgrade/CurrentDatabaseAdministrativeRepairTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/CurrentDatabaseAdministrativeRepairTest.java
@@ -12,7 +12,7 @@ package io.github.dsheirer.database.upgrade;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.github.dsheirer.database.SdrTrunkDatabaseStartup;
+import io.github.dsheirer.database.SdrTrunkTestDatabase;
 import io.github.dsheirer.web.auth.WebAccessService;
 import io.github.dsheirer.web.settings.WebUserPreferences;
 import io.github.dsheirer.web.settings.WebUserPreferencesCodec;
@@ -37,7 +37,7 @@ class CurrentDatabaseAdministrativeRepairTest
     void retainsOnlyTheBoundedUsableWebAccountSet() throws Exception
     {
         Path database = mTemporaryFolder.resolve("bounded-web-users.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         int excessUsers = 32;
         try(Connection connection = open(database))
         {
@@ -64,7 +64,7 @@ class CurrentDatabaseAdministrativeRepairTest
     void preservesCredentialsAndPreferencesWhenOnlyAccountBookkeepingIsDamaged() throws Exception
     {
         Path database = mTemporaryFolder.resolve("repairable-web-account-bookkeeping.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             insertUser(connection, 1, "admin", "ADMIN", true);
@@ -97,7 +97,7 @@ class CurrentDatabaseAdministrativeRepairTest
     void preservesValidAdministrativePayloadsWhenOnlyTheirTimestampsAreDamaged() throws Exception
     {
         Path database = mTemporaryFolder.resolve("repairable-administrative-timestamps.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             execute(connection, "PRAGMA ignore_check_constraints=ON");
@@ -137,7 +137,7 @@ class CurrentDatabaseAdministrativeRepairTest
     void clearsInitializationMarkerWhenMalformedDefaultIconKeyIsDiscarded() throws Exception
     {
         Path database = mTemporaryFolder.resolve("malformed-default-icon-key.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             execute(connection, "DELETE FROM application_icons");

--- a/src/test/java/io/github/dsheirer/database/upgrade/CurrentDatabaseBestEffortRepairTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/CurrentDatabaseBestEffortRepairTest.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.dsheirer.audio.broadcast.rdioscanner.RdioScannerConfiguration;
 import io.github.dsheirer.controller.channel.Channel;
-import io.github.dsheirer.database.SdrTrunkDatabaseStartup;
+import io.github.dsheirer.database.SdrTrunkTestDatabase;
 import io.github.dsheirer.database.configuration.ConfigurationChannelProjection;
 import io.github.dsheirer.database.configuration.ConfigurationRepository;
 import io.github.dsheirer.module.decode.DecoderFactory;
@@ -43,7 +43,7 @@ class CurrentDatabaseBestEffortRepairTest
     void currentFormatInspectionRunsWithSqliteWritesDisabled() throws Exception
     {
         Path database = mTemporaryFolder.resolve("query-only-current-inspection.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database); Statement statement = connection.createStatement())
         {
             statement.execute("PRAGMA query_only=ON");
@@ -55,7 +55,7 @@ class CurrentDatabaseBestEffortRepairTest
     void rejectsOversizedCurrentChannelAndProviderDocumentsBeforeJacksonParsing() throws Exception
     {
         Path database = mTemporaryFolder.resolve("oversized-current-configuration.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String oversizedPadding = "x".repeat(CONFIGURATION_JSON_LIMIT);
 
         try(Connection connection = open(database))
@@ -125,7 +125,7 @@ class CurrentDatabaseBestEffortRepairTest
     void dropsOnlyCurrentAliasesWithMissingOwnersOrInvalidMatchers() throws Exception
     {
         Path database = mTemporaryFolder.resolve("invalid-current-aliases.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database))
         {
@@ -183,7 +183,7 @@ class CurrentDatabaseBestEffortRepairTest
     void defaultsMalformedOptionalAliasFieldsWithoutDroppingTheAlias() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-optional-alias-field-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database))
         {
@@ -240,7 +240,7 @@ class CurrentDatabaseBestEffortRepairTest
     void repairsListsIndependentlyAndSeparatesNamesThatCollideAfterTrimming() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-list-row-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database))
         {
@@ -315,7 +315,7 @@ class CurrentDatabaseBestEffortRepairTest
     void recoversUnicodeBlankCurrentAliasListNameWithoutBlockingOtherConfiguration() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-unicode-blank-alias-list.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database))
         {
@@ -347,7 +347,7 @@ class CurrentDatabaseBestEffortRepairTest
     void createsOneDefaultScanListWhenEverySavedScanListIsUnusable() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-all-scan-lists-unusable.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             execute(connection, "PRAGMA foreign_keys=ON");
@@ -400,7 +400,7 @@ class CurrentDatabaseBestEffortRepairTest
     void remapsOnlyDiscardedDefaultMembershipsWhenAnUnrelatedScanListSurvives() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-discarded-default-membership-recovery.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             execute(connection, "PRAGMA foreign_keys=ON");
@@ -450,7 +450,7 @@ class CurrentDatabaseBestEffortRepairTest
     void repairsProviderBookkeepingWithoutDroppingItsRoutes() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-provider-local-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             RdioScannerConfiguration provider = new RdioScannerConfiguration();
@@ -503,7 +503,7 @@ class CurrentDatabaseBestEffortRepairTest
     void canonicalizesRecoverableCurrentConfigurationIdentifiersWithoutDroppingRoutes() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-configuration-uuid-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             Channel channel = new Channel("Keep uppercase-ID channel");
@@ -602,7 +602,7 @@ class CurrentDatabaseBestEffortRepairTest
     void separatesCanonicalUuidCollisionsBeforeRepairingProvidersChannelsAndRoutes() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-configuration-uuid-collisions.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             Channel channel = new Channel("Keep duplicate-spelling channels");
@@ -715,7 +715,7 @@ class CurrentDatabaseBestEffortRepairTest
     void repairsBlankAliasNamesAndInactiveMatcherColumnsInPlace() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-alias-canonical-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             long p25List = number(connection, "SELECT id FROM alias_list WHERE family='P25' LIMIT 1");
@@ -751,7 +751,7 @@ class CurrentDatabaseBestEffortRepairTest
     void clearsWrongStorageFromInactiveAliasMatcherFields() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-alias-inactive-storage-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             long p25List = number(connection, "SELECT id FROM alias_list WHERE family='P25' LIMIT 1");
@@ -782,7 +782,7 @@ class CurrentDatabaseBestEffortRepairTest
     void dropsOnlyMalformedOptionalChannelSubdocuments() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-channel-optional-component-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             Channel channel = new Channel("Keep core channel");
@@ -832,7 +832,7 @@ class CurrentDatabaseBestEffortRepairTest
     void remapsAnInvalidScanListTargetToTheExistingDefault() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-existing-default-membership-repair.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             long p25List = number(connection, "SELECT id FROM alias_list WHERE family='P25' LIMIT 1");

--- a/src/test/java/io/github/dsheirer/database/upgrade/CurrentDatabaseDerivedStateRepairTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/CurrentDatabaseDerivedStateRepairTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.dsheirer.controller.channel.Channel;
-import io.github.dsheirer.database.SdrTrunkDatabaseStartup;
+import io.github.dsheirer.database.SdrTrunkTestDatabase;
 import io.github.dsheirer.database.configuration.ConfigurationRepository;
 import io.github.dsheirer.module.decode.DecoderFactory;
 import io.github.dsheirer.module.decode.DecoderType;
@@ -40,7 +40,7 @@ class CurrentDatabaseDerivedStateRepairTest
     void resetsTheWholeDerivedComponentForOneCheckViolationAndPreservesTheChannel() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-derived-check.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String configurationId;
 
         try(Connection connection = open(database))
@@ -111,7 +111,7 @@ class CurrentDatabaseDerivedStateRepairTest
     void resetsDerivedStateAndEveryDerivedAllocatorWhenOneSequenceIsExhausted() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-derived-exhausted-sequence.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database))
         {
@@ -167,7 +167,7 @@ class CurrentDatabaseDerivedStateRepairTest
     void resetsDerivedStateForAnOrphanWithoutAdmittingUnknownForeignKeyDamage() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-derived-foreign-key.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         String missingConfiguration = UUID.randomUUID().toString();
 
         try(Connection connection = open(database))
@@ -195,7 +195,7 @@ class CurrentDatabaseDerivedStateRepairTest
     void repairsOnlyInvalidMetricBoundariesWithoutClearingHealthyDerivedState() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-derived-boundaries.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
 
         try(Connection connection = open(database))
         {

--- a/src/test/java/io/github/dsheirer/database/upgrade/Format14TestDatabase.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/Format14TestDatabase.java
@@ -1,13 +1,39 @@
 package io.github.dsheirer.database.upgrade;
 
 import io.github.dsheirer.database.SqliteSchemaValidator;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.sql.DriverManager;
 
 /** Exact populated format 14, derived only through the immutable preceding migration. */
 public final class Format14TestDatabase
 {
-    public static Path create(Path database) throws Exception
+    private static byte[] sTemplate;
+
+    private Format14TestDatabase()
+    {
+    }
+
+    public static synchronized Path create(Path database) throws Exception
+    {
+        Path target = database.toAbsolutePath().normalize();
+        Files.createDirectories(target.getParent());
+
+        if(sTemplate == null)
+        {
+            build(target);
+            sTemplate = Files.readAllBytes(target);
+        }
+        else
+        {
+            Files.write(target, sTemplate, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        }
+
+        return target;
+    }
+
+    private static void build(Path database) throws Exception
     {
         Format13TestDatabase.create(database);
         try(var connection = DriverManager.getConnection("jdbc:sqlite:" + database))
@@ -22,6 +48,5 @@ public final class Format14TestDatabase
                 throw new IllegalStateException("Global format 14 fixture fingerprint mismatch: " + fingerprint);
             }
         }
-        return database;
     }
 }

--- a/src/test/java/io/github/dsheirer/database/upgrade/SqliteIdentityRepairTest.java
+++ b/src/test/java/io/github/dsheirer/database/upgrade/SqliteIdentityRepairTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.dsheirer.database.SdrTrunkDatabaseStartup;
+import io.github.dsheirer.database.SdrTrunkTestDatabase;
 import io.github.dsheirer.database.configuration.ConfigurationIdentityAllocator;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -34,7 +34,7 @@ class SqliteIdentityRepairTest
     void normalizesDuplicateMalformedAndExhaustedCurrentAllocatorRows() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-sequence-damage.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         long retainedMaximum;
 
         try(Connection connection = open(database))
@@ -64,7 +64,7 @@ class SqliteIdentityRepairTest
     void currentApplicationMigrationDoesNotTreatExhaustedSequenceAsANoOp() throws Exception
     {
         Path database = stagedDatabase("current-exhausted-sequence");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             execute(connection, "DELETE FROM sqlite_sequence WHERE name='alias'");
@@ -86,7 +86,7 @@ class SqliteIdentityRepairTest
     void runtimeAllocatorNeverReturnsTheJsonSafeCeiling() throws Exception
     {
         Path database = mTemporaryFolder.resolve("allocator-ceiling.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             execute(connection, "DELETE FROM sqlite_sequence WHERE name='alias'");
@@ -102,7 +102,7 @@ class SqliteIdentityRepairTest
     void preservesRetainedJsonSafeRowAtTheLastAllocatableIdentity() throws Exception
     {
         Path database = mTemporaryFolder.resolve("retained-last-identity.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         long retainedId = SqliteIdentityRepair.JSON_SAFE_INTEGER_MAXIMUM - 1;
         try(Connection connection = open(database))
         {
@@ -127,7 +127,7 @@ class SqliteIdentityRepairTest
     void isolatesOnlyConfigurationRowsAtTheExhaustedJsonSafeBoundary() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-unsafe-identity.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         long owningList;
 
         try(Connection connection = open(database))
@@ -157,7 +157,7 @@ class SqliteIdentityRepairTest
     void currentComponentRepairClassifiesJsonUnsafeAliasAsOneBadItem() throws Exception
     {
         Path database = mTemporaryFolder.resolve("current-component-unsafe-identity.sqlite");
-        SdrTrunkDatabaseStartup.createGlobalDatabase(database);
+        SdrTrunkTestDatabase.create(database);
         try(Connection connection = open(database))
         {
             long owningList = number(connection, "SELECT id FROM alias_list ORDER BY id LIMIT 1");

--- a/src/test/java/io/github/dsheirer/stats/activity/ReceiverActivityServiceLifecycleTest.java
+++ b/src/test/java/io/github/dsheirer/stats/activity/ReceiverActivityServiceLifecycleTest.java
@@ -110,9 +110,9 @@ class ReceiverActivityServiceLifecycleTest
 {
     private static final String ACTIVITY_CONFIGURATION_ID = "123e4567-e89b-12d3-a456-426614174000";
     private static final String LEARNED_P25_CONFIGURATION_ID = "00000000-0000-0000-0000-000000000902";
-    private static final ReceiverActivityService.WriterFactory IMMEDIATE_WRITER_FACTORY =
+    private static final ReceiverActivityService.WriterFactory FAST_WRITER_FACTORY =
         (databasePath, retentionDays, detailedHistory) ->
-            new ReceiverActivityWriter(databasePath, retentionDays, detailedHistory, 10_000, 1_250, 0);
+            new ReceiverActivityWriter(databasePath, retentionDays, detailedHistory, 10_000, 1_250, 25);
 
     @TempDir
     Path mTemporaryFolder;
@@ -165,7 +165,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
 
         disposeAndAwait(service);
         service.preferenceUpdated(PreferenceType.APPLICATION);
@@ -182,7 +182,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         Channel channel = new Channel("Observer isolation", Channel.ChannelType.STANDARD);
         channel.setDecodeConfiguration(new DecodeConfigNBFM());
         CountDownLatch projectionEntered = new CountDownLatch(1);
@@ -246,7 +246,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         CountDownLatch projectionEntered = new CountDownLatch(1);
         CountDownLatch releaseProjection = new CountDownLatch(1);
         long start = System.currentTimeMillis();
@@ -354,7 +354,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         CountDownLatch projectionEntered = new CountDownLatch(1);
         CountDownLatch releaseProjection = new CountDownLatch(1);
         long now = System.currentTimeMillis();
@@ -455,7 +455,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         CountDownLatch projectionEntered = new CountDownLatch(1);
         CountDownLatch releaseProjection = new CountDownLatch(1);
         long start = System.currentTimeMillis();
@@ -566,7 +566,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         CountDownLatch projectionEntered = new CountDownLatch(1);
         CountDownLatch releaseProjection = new CountDownLatch(1);
         long start = System.currentTimeMillis();
@@ -674,7 +674,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         Channel channel = new Channel("Drain barrier saturation", Channel.ChannelType.STANDARD);
         channel.setDecodeConfiguration(new DecodeConfigNBFM());
         CountDownLatch projectionEntered = new CountDownLatch(1);
@@ -715,7 +715,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         Channel channel = new Channel("Interrupted drain barrier", Channel.ChannelType.STANDARD);
         channel.setDecodeConfiguration(new DecodeConfigNBFM());
         CountDownLatch projectionEntered = new CountDownLatch(1);
@@ -760,7 +760,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         Channel channel = new Channel("Retired drain epoch", Channel.ChannelType.STANDARD);
         channel.setDecodeConfiguration(new DecodeConfigNBFM());
         CountDownLatch projectionEntered = new CountDownLatch(1);
@@ -870,7 +870,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         Channel blockerChannel = new Channel("Logical output saturation", Channel.ChannelType.STANDARD);
         blockerChannel.setDecodeConfiguration(new DecodeConfigNBFM());
         CountDownLatch projectionEntered = new CountDownLatch(1);
@@ -1031,7 +1031,7 @@ class ReceiverActivityServiceLifecycleTest
             }
         };
         ReceiverActivityService service = new ReceiverActivityService(userPreferences, 2, TimeUnit.SECONDS,
-            pauseAfterSnapshot, null, IMMEDIATE_WRITER_FACTORY);
+            pauseAfterSnapshot, null, FAST_WRITER_FACTORY);
         long oldTimestamp = System.currentTimeMillis();
         long disabledTimestamp = oldTimestamp + 5_000L;
         long newTimestamp = oldTimestamp + 10_000L;
@@ -1133,7 +1133,7 @@ class ReceiverActivityServiceLifecycleTest
             }
         };
         ReceiverActivityService service = new ReceiverActivityService(userPreferences, 2, TimeUnit.SECONDS,
-            pauseAfterSnapshot, null, IMMEDIATE_WRITER_FACTORY);
+            pauseAfterSnapshot, null, FAST_WRITER_FACTORY);
         long frequency = 154_310_000L;
         long start = System.currentTimeMillis();
         DecodeEvent context = DecodeEvent.builder(DecodeEventType.CALL, start)
@@ -1251,7 +1251,7 @@ class ReceiverActivityServiceLifecycleTest
             }
         };
         ReceiverActivityService service = new ReceiverActivityService(userPreferences, 2, TimeUnit.SECONDS,
-            pauseAfterSnapshot, pauseBeforeActivation, IMMEDIATE_WRITER_FACTORY);
+            pauseAfterSnapshot, pauseBeforeActivation, FAST_WRITER_FACTORY);
         long start = System.currentTimeMillis();
         DecodeEvent oldActive = conventionalEvent(start);
         DecodeEvent inactive = conventionalEvent(start + 5_000L);
@@ -1663,7 +1663,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         P25TrafficChannelManager manager = new P25TrafficChannelManager(channel);
         manager.addDecodeEventListener(event -> service.getDecodeEventListener().accept(channel, event));
         MutableIdentifierCollection identifiers = new MutableIdentifierCollection();
@@ -1704,7 +1704,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30, true);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = new ReceiverActivityService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
         long frequency = 154_310_000L;
         long start = System.currentTimeMillis();
 
@@ -1775,7 +1775,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(false, 30);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
 
         try
         {
@@ -1839,7 +1839,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(false, 30);
         TestUserPreferences userPreferences = new TestUserPreferences(applicationPreference,
             new TestDirectoryPreference(mTemporaryFolder.resolve("missing-portable-data")));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
 
         try
         {
@@ -1871,7 +1871,7 @@ class ReceiverActivityServiceLifecycleTest
         TestApplicationPreference applicationPreference = new TestApplicationPreference(true, 30);
         TestUserPreferences userPreferences =
             new TestUserPreferences(applicationPreference, new TestDirectoryPreference(mTemporaryFolder));
-        ReceiverActivityService service = immediateWriterService(userPreferences);
+        ReceiverActivityService service = fastWriterService(userPreferences);
 
         try
         {
@@ -2148,10 +2148,10 @@ class ReceiverActivityServiceLifecycleTest
         }
     }
 
-    private static ReceiverActivityService immediateWriterService(UserPreferences userPreferences)
+    private static ReceiverActivityService fastWriterService(UserPreferences userPreferences)
     {
         return new ReceiverActivityService(userPreferences, 2, TimeUnit.SECONDS, null, null,
-            IMMEDIATE_WRITER_FACTORY);
+            FAST_WRITER_FACTORY);
     }
 
     private static class TestUserPreferences extends UserPreferences


### PR DESCRIPTION
## Summary
- run ordinary migration-service tests in-process while retaining both real child-process command forms
- reuse one verified, fully checkpointed current-schema fixture for isolated migration and repair tests
- preserve every migration assertion and the dedicated startup/schema coverage

## Verification
- full clean build: 2,395 tests, 0 failures, 3 skipped
- focused migration-service suite: 46 tests, 0 failures
- focused migrator/repair suites: 74 tests, 0 failures

This PR is also the Windows timing gate before the next nightly publication.