### PR TITLE
Add obvious launchers to package roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ These older or experimental features are not included:
 1. Choose a [numbered Alpha](https://github.com/tylerwatt12/sdrtrunk-vce/releases/latest) or the
    [current Nightly](https://github.com/tylerwatt12/sdrtrunk-vce/releases/tag/nightly).
 2. Extract it into a new writable folder.
-3. Start `bin/sdrtrunk-vce` on macOS or Linux, or `bin\sdrtrunk-vce.bat` on Windows.
+3. Use the `Start SDRTrunk VCE` launcher in the extracted folder. Its extension identifies Windows (`.bat`), macOS
+   (`.command`), or Linux (`.sh`).
 4. Import XML, migrate a previous VCE setup, or start fresh.
 5. Review the imported channels and file locations before enabling auto-start.
 

--- a/build.gradle
+++ b/build.gradle
@@ -466,6 +466,7 @@ def runtimeTargets = [
                 size: 145580094L,
                 sha256: '3f28b269a6e29a77187546da32eb2474fd4b8f4c8b73b7bb1c934d5f9b98bb8f',
                 releaseArchitecture: 'aarch64',
+                rootLauncher: 'Start SDRTrunk VCE.sh',
                 windows: false
         ],
         [
@@ -478,6 +479,7 @@ def runtimeTargets = [
                 size: 142411056L,
                 sha256: '5dd2f7ef72c66b095f3c29ba1c2944e3b651870d534f4745ef46936d3d3447c8',
                 releaseArchitecture: 'x86_64',
+                rootLauncher: 'Start SDRTrunk VCE.sh',
                 windows: false
         ],
         [
@@ -490,6 +492,7 @@ def runtimeTargets = [
                 size: 122063016L,
                 sha256: '72442fad43060b0e2f94b6559d5b375ccb45182b1b291d2e03c74eb7672c8383',
                 releaseArchitecture: 'aarch64',
+                rootLauncher: 'Start SDRTrunk VCE.command',
                 windows: false
         ],
         [
@@ -502,6 +505,7 @@ def runtimeTargets = [
                 size: 127114406L,
                 sha256: 'f928dd4a3d3b726645a03d2b987803b9163592c8a29a5e4cf0598136daa6a04e',
                 releaseArchitecture: 'x86_64',
+                rootLauncher: 'Start SDRTrunk VCE.command',
                 windows: false
         ],
         [
@@ -514,6 +518,7 @@ def runtimeTargets = [
                 size: 48590725L,
                 sha256: '2276f80f1a4dbbe531379a38cf00cb91ed79ce057dbc70f5cf2b53f5d24402ee',
                 releaseArchitecture: 'aarch64',
+                rootLauncher: 'Start SDRTrunk VCE.bat',
                 windows: true
         ],
         [
@@ -526,6 +531,7 @@ def runtimeTargets = [
                 size: 118973801L,
                 sha256: '0d855829d51b49dd7a54bf0be930408ebbff8bbd487fdac287237468f2cd33c0',
                 releaseArchitecture: 'x86_64',
+                rootLauncher: 'Start SDRTrunk VCE.bat',
                 windows: true
         ]
 ]
@@ -638,8 +644,18 @@ def verifyRuntimePackage = { Map target, File archive ->
             throw new GradleException("Package contains empty directories: ${emptyDirectories*.name}")
         }
 
+        def rootLaunchers = entries.findAll { entry ->
+            !entry.directory && entry.name.startsWith("${root}/Start SDRTrunk VCE.")
+        }*.name as Set
+        Set<String> expectedRootLaunchers = ["${root}/${target.rootLauncher}"] as Set
+
+        if(rootLaunchers != expectedRootLaunchers) {
+            throw new GradleException("Package ${archive.name} has unexpected root launchers: ${rootLaunchers}")
+        }
+
         [
                 runtimeLauncher,
+                "${root}/${target.rootLauncher}",
                 "${root}/bin/${packagedApplicationName}",
                 "${root}/bin/${packagedApplicationName}.bat",
                 applicationJar,
@@ -649,6 +665,18 @@ def verifyRuntimePackage = { Map target, File archive ->
                 "${root}/NOTICE",
                 "${root}/release"
         ].each { archiveEntryBytes(zip, it) }
+
+        String rootLauncherText = archiveEntryText(zip, "${root}/${target.rootLauncher}")
+
+        if(target.windows) {
+            if(!rootLauncherText.contains('@"%~dp0bin\\sdrtrunk-vce.bat" %*')) {
+                throw new GradleException("Root launcher does not forward to the Windows application launcher")
+            }
+        }
+        else if(!rootLauncherText.startsWith('#!/bin/sh\n') ||
+                !rootLauncherText.contains('exec "$launcher_root/bin/sdrtrunk-vce" "$@"')) {
+            throw new GradleException("Root launcher does not forward to the Unix application launcher")
+        }
 
         if(zip.getEntry("${root}/bin/javac") != null || zip.getEntry("${root}/bin/javac.exe") != null) {
             throw new GradleException("Package ${archive.name} contains a JDK instead of the smaller JRE")
@@ -924,6 +952,14 @@ runtimeTargets.each { target ->
         if(!target.windows) {
             from(target.materializedLegalDirectory) {
                 into(target.packageRoot)
+            }
+        }
+
+        from("packaging/launchers/${target.rootLauncher}") {
+            into(target.packageRoot)
+
+            if(!target.windows) {
+                filePermissions { unix('rwxr-xr-x') }
             }
         }
 

--- a/packaging/launchers/Start SDRTrunk VCE.bat
+++ b/packaging/launchers/Start SDRTrunk VCE.bat
@@ -1,0 +1,2 @@
+@echo off
+@"%~dp0bin\sdrtrunk-vce.bat" %*

--- a/packaging/launchers/Start SDRTrunk VCE.command
+++ b/packaging/launchers/Start SDRTrunk VCE.command
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+launcher_root=$(CDPATH= cd -P "$(dirname "$0")" && pwd) || exit 1
+exec "$launcher_root/bin/sdrtrunk-vce" "$@"

--- a/packaging/launchers/Start SDRTrunk VCE.sh
+++ b/packaging/launchers/Start SDRTrunk VCE.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+launcher_root=$(CDPATH= cd -P "$(dirname "$0")" && pwd) || exit 1
+exec "$launcher_root/bin/sdrtrunk-vce" "$@"


### PR DESCRIPTION
## Summary
- add one clearly named launcher at the root of each extracted package
- keep the generated launchers in `bin` as the single implementation
- verify that each ZIP contains only the launcher for its operating system
- update the installation instructions

## Verification
- built and verified all six runtime ZIPs in 1m 30s
- confirmed all four Unix launchers are executable in their ZIPs
- launched the macOS ARM package from an extracted path containing spaces using its bundled Java
- checked both POSIX wrapper scripts with `sh -n`
- checked the staged diff with `git diff --check`

The startup console log supplied separately was reviewed; it shows a successful launch and does not require a code change in this PR.