### PR TITLE
Remove races from USB and DMR checks

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/manager/TunerManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/TunerManager.java
@@ -265,7 +265,7 @@ public class TunerManager implements IDiscoveredTunerStatusListener
                 return CompletableFuture.completedFuture(USB_RESCAN_UNAVAILABLE);
             }
 
-            if(mUsbRescan != null)
+            if(mUsbRescan != null && !mUsbRescan.isDone())
             {
                 return mUsbRescan;
             }

--- a/src/test/java/io/github/dsheirer/controller/channel/ChannelProcessingManagerDMRRestHandoffTest.java
+++ b/src/test/java/io/github/dsheirer/controller/channel/ChannelProcessingManagerDMRRestHandoffTest.java
@@ -1246,9 +1246,13 @@ class ChannelProcessingManagerDMRRestHandoffTest
 
             trafficManager.requestRestChannelHandoff(parent, CURRENT_FREQUENCY,
                 restChannel(3, FIRST_REST_FREQUENCY));
-            assertTrue(awaitCondition(() -> manager.getPendingDmrRestChannelAttemptCount() == 0 &&
-                manager.getProcessingChain(parent) != null && manager.getProcessingChain(parent) != expectedOriginal &&
-                manager.getProcessingChain(parent).getSource().getFrequency() == FIRST_REST_FREQUENCY, 5),
+            assertTrue(awaitCondition(() ->
+            {
+                ProcessingChain current = manager.getProcessingChain(parent);
+                Source source = current != null ? current.getSource() : null;
+                return manager.getPendingDmrRestChannelAttemptCount() == 0 && current != expectedOriginal &&
+                    source != null && source.getFrequency() == FIRST_REST_FREQUENCY;
+            }, 5),
                 "manager rollback did not make the pooled channel reusable for a retry");
             assertEquals(2, tunerManager.getSourceRequests());
         }

--- a/src/test/java/io/github/dsheirer/source/tuner/manager/TunerManagerUsbRescanTest.java
+++ b/src/test/java/io/github/dsheirer/source/tuner/manager/TunerManagerUsbRescanTest.java
@@ -75,8 +75,11 @@ class TunerManagerUsbRescanTest
 
         try
         {
-            assertEquals(0, manager.requestUsbTunerRescan().get(5, TimeUnit.SECONDS));
-            assertEquals(0, manager.requestUsbTunerRescan().get(5, TimeUnit.SECONDS));
+            CompletableFuture<Integer> first = manager.requestUsbTunerRescan();
+            assertEquals(0, first.get(5, TimeUnit.SECONDS));
+            CompletableFuture<Integer> second = manager.requestUsbTunerRescan();
+            assertNotSame(first, second);
+            assertEquals(0, second.get(5, TimeUnit.SECONDS));
             assertEquals(2, scanCount.get());
         }
         finally


### PR DESCRIPTION
## Summary
- start a fresh USB rescan whenever the previous scan has already finished
- keep active USB rescan requests coalesced exactly as before
- make the USB regression test verify that consecutive scans are distinct
- snapshot one changing DMR processing chain during its wait condition so the test cannot trip over its own repeated reads

## Intentionally unchanged
- CI workflow and three-OS gate
- retries, quarantines, test categories, and test framework
- migration and data-integrity assertions
- existing timeouts and all unrelated tests

## Verification
- focused USB rescan class and proven DMR failure method passed
- full `clean check`: 2,395 tests, 0 failures, 0 errors, 3 existing skips
- `git diff --check` passed